### PR TITLE
Add signals in QWBackend

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES
     render/qwrenderer.cpp
     render/qwtexture.cpp
     types/qwbuffer.cpp
+    util/qwsignalconnector.cpp
 )
 
 set(HEADERS
@@ -35,6 +36,7 @@ set(HEADERS
     render/qwrenderer.h
     render/qwtexture.h
     types/qwbuffer.h
+    util/qwsignalconnector.h
 )
 
 add_library(${TARGET}

--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwbackend.h"
+#include "util/qwsignalconnector.h"
 
 extern "C" {
 #include <wlr/backend.h>
@@ -15,19 +16,42 @@ public:
     QWBackendPrivate(void *handle, QWBackend *qq)
         : QWObjectPrivate(handle, qq)
     {
-
+        sc.connect(&this->handle()->events.new_input, this, &QWBackendPrivate::on_new_input);
+        sc.connect(&this->handle()->events.new_input, this, &QWBackendPrivate::on_new_output);
+        sc.connect(&this->handle()->events.destroy, &sc, &QWSignalConnector::invalidate);
     }
     ~QWBackendPrivate() {
         Q_ASSERT(handle());
         wlr_backend_destroy(handle());
     }
 
+    void on_new_input(void *data);
+    void on_new_output(void *data);
+
     inline wlr_backend *handle() const {
         return q_func()->handle<wlr_backend>();
     }
 
     QW_DECLARE_PUBLIC(QWBackend)
+    QWSignalConnector sc;
 };
+
+
+void QWBackendPrivate::on_new_input(void *data)
+{
+    Q_Q(QWBackend);
+    auto device = reinterpret_cast<wlr_input_device*>(data);
+    Q_ASSERT(device);
+    Q_EMIT q->newInput(device);
+}
+
+void QWBackendPrivate::on_new_output(void *data)
+{
+    Q_Q(QWBackend);
+    auto output = reinterpret_cast<wlr_output*>(data);
+    Q_ASSERT(output);
+    Q_EMIT q->newOutput(output);
+}
 
 QWBackend *QWBackend::autoCreate(wl_display *display, QObject *parent)
 {

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -6,6 +6,8 @@
 #include <qwglobal.h>
 #include <QObject>
 
+struct wlr_input_device;
+struct wlr_output;
 struct wl_display;
 
 QW_BEGIN_NAMESPACE
@@ -23,6 +25,12 @@ public:
 
 public Q_SLOTS:
     bool start();
+
+Q_SIGNALS:
+    // TODO: make to QWInputDevice
+    void newInput(wlr_input_device *device);
+    // TODO: make to QWOutput
+    void newOutput(wlr_output *output);
 
 private:
     explicit QWBackend(void *handle, QObject *parent = nullptr);

--- a/src/util/qwsignalconnector.cpp
+++ b/src/util/qwsignalconnector.cpp
@@ -1,0 +1,144 @@
+// Copyright (C) 2022 zccrs zccrs@live.com.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#include "qwsignalconnector.h"
+
+#include <wayland-server-core.h>
+
+QW_BEGIN_NAMESPACE
+
+struct Listener {
+    wl_signal *signal;
+    wl_listener l;
+    void *object;
+    union {
+        QWSignalConnector::SlotFun0 slot0;
+        QWSignalConnector::SlotFun1 slot1;
+        QWSignalConnector::SlotFun2 slot2;
+    };
+    void *data;
+};
+
+static void callSlot0(wl_listener *wl_listener, void *) {
+    Listener *listener = wl_container_of(wl_listener, listener, l);
+    listener->slot0(listener->object);
+}
+
+static void callSlot1(wl_listener *wl_listener, void *data) {
+    Listener *listener = wl_container_of(wl_listener, listener, l);
+    listener->slot1(listener->object, data);
+}
+
+static void callSlot2(wl_listener *wl_listener, void *data) {
+    Listener *listener = wl_container_of(wl_listener, listener, l);
+    listener->slot2(listener->object, data, listener->data);
+}
+
+QWSignalConnector::QWSignalConnector()
+{
+    listenerList.reserve(1);
+}
+
+QWSignalConnector::~QWSignalConnector()
+{
+    auto begin = listenerList.begin();
+    while (begin != listenerList.end()) {
+        Listener *l = *begin;
+        wl_list_remove(&l->l.link);
+        delete l;
+        ++begin;
+    }
+}
+
+Listener *QWSignalConnector::connect(wl_signal *signal, void *object, SlotFun0 slot)
+{
+    Listener *l = new Listener;
+    listenerList.push_back(l);
+
+    l->signal = signal;
+    l->l.notify = callSlot0;
+    l->object = object;
+    l->slot0 = slot;
+    wl_signal_add(signal, &l->l);
+    return l;
+}
+
+Listener *QWSignalConnector::connect(wl_signal *signal, void *object, SlotFun1 slot)
+{
+    Listener *l = new Listener;
+    listenerList.push_back(l);
+
+    l->signal = signal;
+    l->l.notify = callSlot1;
+    l->object = object;
+    l->slot1 = slot;
+    wl_signal_add(signal, &l->l);
+    return l;
+}
+
+Listener *QWSignalConnector::connect(wl_signal *signal, void *object, SlotFun2 slot, void *data)
+{
+    Q_ASSERT(data);
+    Listener *l = new Listener;
+    listenerList.push_back(l);
+
+    l->signal = signal;
+    l->l.notify = callSlot2;
+    l->object = object;
+    l->slot2 = slot;
+    l->data = data;
+    wl_signal_add(signal, &l->l);
+    return l;
+}
+
+void QWSignalConnector::disconnect(Listener *l)
+{
+    Q_ASSERT(listenerList.contains(l));
+    wl_list_remove(&l->l.link);
+    delete l;
+    listenerList.removeOne(l);
+}
+
+void QWSignalConnector::disconnect(wl_signal *signal)
+{
+    auto tmpList = listenerList;
+    auto begin = tmpList.begin();
+    while (begin != tmpList.end()) {
+        Listener *l = *begin;
+        ++begin;
+
+        if (signal == l->signal)
+            disconnect(l);
+    }
+}
+
+// In this function will not remove the wl_list, use in the destroy
+// the corresponding wlr object before.
+void QWSignalConnector::invalidate()
+{
+    auto tmpList = listenerList;
+    listenerList.clear();
+    auto begin = tmpList.begin();
+    while (begin != tmpList.end()) {
+        Listener *l = *begin;
+        ++begin;
+        delete l;
+    }
+}
+
+void QWSignalConnector::invalidate(wl_signal *signal)
+{
+    auto tmpList = listenerList;
+    auto begin = tmpList.begin();
+    while (begin != tmpList.end()) {
+        Listener *l = *begin;
+        ++begin;
+
+        if (signal == l->signal) {
+            delete l;
+            listenerList.removeOne(l);
+        }
+    }
+}
+
+QW_END_NAMESPACE

--- a/src/util/qwsignalconnector.h
+++ b/src/util/qwsignalconnector.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 zccrs zccrs@live.com.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include <qwglobal.h>
+#include <QVector>
+
+struct wl_signal;
+
+QW_BEGIN_NAMESPACE
+
+struct Listener;
+class QW_EXPORT QWSignalConnector {
+public:
+    QWSignalConnector();
+    ~QWSignalConnector();
+
+    typedef void (*SlotFun0)(void *obj);
+    Listener *connect(wl_signal *signal, void *object, SlotFun0 slot);
+    typedef void (*SlotFun1)(void *obj, void *signalData);
+    Listener *connect(wl_signal *signal, void *object, SlotFun1 slot);
+    typedef void (*SlotFun2)(void *obj, void *signalData, void *data);
+    Listener *connect(wl_signal *signal, void *object, SlotFun2 slot, void *data);
+    template <typename T>
+    inline Listener *connect(wl_signal *signal, T *object, void (T::*slot)()) {
+        return connect(signal, object, reinterpret_cast<SlotFun0>(*(void**)(&slot)));
+    }
+    template <typename T>
+    inline Listener *connect(wl_signal *signal, T *object, void (T::*slot)(void*)) {
+        return connect(signal, object, reinterpret_cast<SlotFun1>(*(void**)(&slot)));
+    }
+    template <typename T>
+    inline Listener *connect(wl_signal *signal, T *object, void (T::*slot)(void*, void*), void *data) {
+        return connect(signal, object, reinterpret_cast<SlotFun2>(*(void**)(&slot)), data);
+    }
+    void disconnect(Listener *l);
+    void disconnect(wl_signal *signal);
+    void invalidate();
+    void invalidate(wl_signal *signal);
+
+private:
+    QVector<Listener*> listenerList;
+};
+
+QW_END_NAMESPACE


### PR DESCRIPTION
Add newInput and newOutput signals.
Add QWSignalConnector class to easier to connect a wl_signal, the class is copy from Waylib's WSignalconnector, it like as Qt signal-slot design.