### PR TITLE
Allow to construction QW* object

### DIFF
--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -16,21 +16,17 @@ public:
     QWBackendPrivate(void *handle, QWBackend *qq)
         : QWObjectPrivate(handle, qq)
     {
-        sc.connect(&this->handle()->events.new_input, this, &QWBackendPrivate::on_new_input);
-        sc.connect(&this->handle()->events.new_input, this, &QWBackendPrivate::on_new_output);
-        sc.connect(&this->handle()->events.destroy, &sc, &QWSignalConnector::invalidate);
+        sc.connect(&qq->handle()->events.new_input, this, &QWBackendPrivate::on_new_input);
+        sc.connect(&qq->handle()->events.new_input, this, &QWBackendPrivate::on_new_output);
+        sc.connect(&qq->handle()->events.destroy, &sc, &QWSignalConnector::invalidate);
     }
     ~QWBackendPrivate() {
-        Q_ASSERT(handle());
-        wlr_backend_destroy(handle());
+        Q_ASSERT(q_func()->handle());
+        wlr_backend_destroy(q_func()->handle());
     }
 
     void on_new_input(void *data);
     void on_new_output(void *data);
-
-    inline wlr_backend *handle() const {
-        return q_func()->handle<wlr_backend>();
-    }
 
     QW_DECLARE_PUBLIC(QWBackend)
     QWSignalConnector sc;
@@ -61,7 +57,7 @@ QWBackend *QWBackend::autoCreate(wl_display *display, QObject *parent)
     return new QWBackend(handle, parent);
 }
 
-QWBackend::QWBackend(void *handle, QObject *parent)
+QWBackend::QWBackend(wlr_backend *handle, QObject *parent)
     : QObject(parent)
     , QWObject(*new QWBackendPrivate(handle, this))
 {
@@ -76,19 +72,19 @@ QWBackend::~QWBackend()
 clockid_t QWBackend::presentationClock() const
 {
     Q_D(const QWBackend);
-    return wlr_backend_get_presentation_clock(d->handle());
+    return wlr_backend_get_presentation_clock(handle());
 }
 
 int QWBackend::drmFd() const
 {
     Q_D(const QWBackend);
-    return wlr_backend_get_drm_fd(d->handle());
+    return wlr_backend_get_drm_fd(handle());
 }
 
 bool QWBackend::start()
 {
     Q_D(QWBackend);
-    return wlr_backend_start(d->handle());
+    return wlr_backend_start(handle());
 }
 
 QW_END_NAMESPACE

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -6,6 +6,7 @@
 #include <qwglobal.h>
 #include <QObject>
 
+struct wlr_backend;
 struct wlr_input_device;
 struct wlr_output;
 struct wl_display;
@@ -17,8 +18,14 @@ class QW_EXPORT QWBackend : public QObject, public QWObject
 {
     QW_DECLARE_PRIVATE(QWBackend)
 public:
-    static QWBackend *autoCreate(wl_display *display, QObject *parent = nullptr);
+    explicit QWBackend(wlr_backend *handle, QObject *parent = nullptr);
     ~QWBackend();
+
+    static QWBackend *autoCreate(wl_display *display, QObject *parent = nullptr);
+
+    inline wlr_backend *handle() const {
+        return QWObject::handle<wlr_backend>();
+    }
 
     clockid_t presentationClock() const;
     int drmFd() const;
@@ -31,9 +38,6 @@ Q_SIGNALS:
     void newInput(wlr_input_device *device);
     // TODO: make to QWOutput
     void newOutput(wlr_output *output);
-
-private:
-    explicit QWBackend(void *handle, QObject *parent = nullptr);
 };
 
 QW_END_NAMESPACE

--- a/src/render/qwrenderer.cpp
+++ b/src/render/qwrenderer.cpp
@@ -30,22 +30,18 @@ public:
         // m_handle destory follow the wlr_backend
     }
 
-    inline wlr_renderer *handle() const {
-        return q_func()->handle<wlr_renderer>();
-    }
-
     QW_DECLARE_PUBLIC(QWRenderer)
 };
 
 QWRenderer *QWRenderer::autoCreate(QWBackend *backend)
 {
-    auto handle = wlr_renderer_autocreate(backend->handle<wlr_backend>());
+    auto handle = wlr_renderer_autocreate(backend->handle());
     if (!handle)
         return nullptr;
     return new QWRenderer(handle, backend);
 }
 
-QWRenderer::QWRenderer(void *handle, QObject *parent)
+QWRenderer::QWRenderer(wlr_renderer *handle, QObject *parent)
     : QObject(parent)
     , QWObject(*new QWRendererPrivate(handle, this))
 {
@@ -60,37 +56,37 @@ QWRenderer::~QWRenderer()
 void QWRenderer::begin(uint32_t width, uint32_t height)
 {
     Q_D(QWRenderer);
-    wlr_renderer_begin(d->handle(), width, height);
+    wlr_renderer_begin(handle(), width, height);
 }
 
 void QWRenderer::begin(QWBuffer *buffer)
 {
     Q_D(QWRenderer);
-    wlr_renderer_begin_with_buffer(d->handle(), buffer->handle<wlr_buffer>());
+    wlr_renderer_begin_with_buffer(handle(), buffer->handle());
 }
 
 void QWRenderer::end()
 {
     Q_D(QWRenderer);
-    wlr_renderer_end(d->handle());
+    wlr_renderer_end(handle());
 }
 
 bool QWRenderer::initWlDisplay(wl_display *display)
 {
     Q_D(QWRenderer);
-    return wlr_renderer_init_wl_display(d->handle(), display);
+    return wlr_renderer_init_wl_display(handle(), display);
 }
 
 bool QWRenderer::initWlShm(wl_display *display)
 {
     Q_D(QWRenderer);
-    return wlr_renderer_init_wl_shm(d->handle(), display);
+    return wlr_renderer_init_wl_shm(handle(), display);
 }
 
 void QWRenderer::clear(const float *color)
 {
     Q_D(QWRenderer);
-    wlr_renderer_clear(d->handle(), color);
+    wlr_renderer_clear(handle(), color);
 }
 
 void QWRenderer::clear(const QColor &color)
@@ -107,7 +103,7 @@ void QWRenderer::clear(const QColor &color)
 void QWRenderer::scissor(wlr_box *box)
 {
     Q_D(QWRenderer);
-    wlr_renderer_scissor(d->handle(), box);
+    wlr_renderer_scissor(handle(), box);
 }
 
 void QWRenderer::scissor(const QRect &box)
@@ -125,25 +121,25 @@ void QWRenderer::scissor(const QRect &box)
 void QWRenderer::renderTexture(QWTexture *texture, const float *projection, int x, int y, float alpha)
 {
     Q_D(QWRenderer);
-    wlr_render_texture(d->handle(), texture->handle<wlr_texture>(), projection, x, y, alpha);
+    wlr_render_texture(handle(), texture->handle(), projection, x, y, alpha);
 }
 
 void QWRenderer::renderTexture(QWTexture *texture, const float *matrix, float alpha)
 {
     Q_D(QWRenderer);
-    wlr_render_texture_with_matrix(d->handle(), texture->handle<wlr_texture>(), matrix, alpha);
+    wlr_render_texture_with_matrix(handle(), texture->handle(), matrix, alpha);
 }
 
 void QWRenderer::renderSubtexture(QWTexture *texture, wlr_fbox *fbox, const float *matrix, float alpha)
 {
     Q_D(QWRenderer);
-    wlr_render_subtexture_with_matrix(d->handle(), texture->handle<wlr_texture>(), fbox, matrix, alpha);
+    wlr_render_subtexture_with_matrix(handle(), texture->handle(), fbox, matrix, alpha);
 }
 
 void QWRenderer::renderRect(const wlr_box *box, const float *color, const float *projection)
 {
     Q_D(QWRenderer);
-    wlr_render_rect(d->handle(), box, color, projection);
+    wlr_render_rect(handle(), box, color, projection);
 }
 
 void QWRenderer::renderRect(const QRect &box, const QColor &color, const QMatrix3x3 &projection)
@@ -168,7 +164,7 @@ void QWRenderer::renderRect(const QRect &box, const QColor &color, const QMatrix
 void QWRenderer::renderQuad(const float *color, const float *matrix)
 {
     Q_D(QWRenderer);
-    wlr_render_quad_with_matrix(d->handle(), color, matrix);
+    wlr_render_quad_with_matrix(handle(), color, matrix);
 }
 
 void QWRenderer::renderQuad(const QColor &color, const QMatrix3x3 &matrix)
@@ -186,26 +182,26 @@ void QWRenderer::renderQuad(const QColor &color, const QMatrix3x3 &matrix)
 const uint32_t *QWRenderer::getShmTextureFormats(size_t *len) const
 {
     Q_D(const QWRenderer);
-    return wlr_renderer_get_shm_texture_formats(d->handle(), len);
+    return wlr_renderer_get_shm_texture_formats(handle(), len);
 }
 
 const wlr_drm_format_set *QWRenderer::getDmabufTextureFormats() const
 {
     Q_D(const QWRenderer);
-    return wlr_renderer_get_dmabuf_texture_formats(d->handle());
+    return wlr_renderer_get_dmabuf_texture_formats(handle());
 }
 
 bool QWRenderer::readPixels(uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
                             uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data) const
 {
     Q_D(const QWRenderer);
-    return wlr_renderer_read_pixels(d->handle(), fmt, stride, width, height, src_x, src_y, dst_x, dst_y, data);
+    return wlr_renderer_read_pixels(handle(), fmt, stride, width, height, src_x, src_y, dst_x, dst_y, data);
 }
 
 int QWRenderer::getDrmFd() const
 {
     Q_D(const QWRenderer);
-    return wlr_renderer_get_drm_fd(d->handle());
+    return wlr_renderer_get_drm_fd(handle());
 }
 
 QW_END_NAMESPACE

--- a/src/render/qwrenderer.h
+++ b/src/render/qwrenderer.h
@@ -7,6 +7,7 @@
 #include <QObject>
 #include <QMatrix3x3>
 
+struct wlr_renderer;
 struct wlr_box;
 struct wlr_fbox;
 struct wlr_drm_format_set;
@@ -22,8 +23,14 @@ class QW_EXPORT QWRenderer : public QObject, public QWObject
 {
     QW_DECLARE_PRIVATE(QWRenderer)
 public:
-    static QWRenderer *autoCreate(QWBackend *backend);
+    explicit QWRenderer(wlr_renderer *handle, QObject *parent = nullptr);
     ~QWRenderer();
+
+    static QWRenderer *autoCreate(QWBackend *backend);
+
+    inline wlr_renderer *handle() const {
+        return QWObject::handle<wlr_renderer>();
+    }
 
     void begin(uint32_t width, uint32_t height);
     void begin(QWBuffer *buffer);
@@ -49,9 +56,6 @@ public:
     bool readPixels(uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
                     uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data) const;
     int getDrmFd() const;
-
-private:
-    explicit QWRenderer(void *handle, QObject *parent = nullptr);
 };
 
 QW_END_NAMESPACE

--- a/src/render/qwtexture.cpp
+++ b/src/render/qwtexture.cpp
@@ -20,17 +20,14 @@ public:
 
     }
     ~QWTexturePrivate() {
-        wlr_texture_destroy(handle());
-    }
-
-    inline wlr_texture *handle() const {
-        return q_func()->handle<wlr_texture>();
+        Q_ASSERT(q_func()->handle());
+        wlr_texture_destroy(q_func()->handle());
     }
 
     QW_DECLARE_PUBLIC(QWTexture)
 };
 
-QWTexture::QWTexture(void *handle)
+QWTexture::QWTexture(wlr_texture *handle)
     : QWObject(*new QWTexturePrivate(handle, this))
 {
 
@@ -39,7 +36,7 @@ QWTexture::QWTexture(void *handle)
 QWTexture *QWTexture::fromPixels(QWRenderer *renderer, uint32_t fmt, uint32_t stride,
                                  uint32_t width, uint32_t height, const void *data)
 {
-    auto texture = wlr_texture_from_pixels(renderer->handle<wlr_renderer>(),
+    auto texture = wlr_texture_from_pixels(renderer->handle(),
                                            fmt, stride, width, height, data);
     if (!texture)
         return nullptr;
@@ -48,7 +45,7 @@ QWTexture *QWTexture::fromPixels(QWRenderer *renderer, uint32_t fmt, uint32_t st
 
 QWTexture *QWTexture::fromDmabuf(QWRenderer *renderer, wlr_dmabuf_attributes *attribs)
 {
-    auto texture = wlr_texture_from_dmabuf(renderer->handle<wlr_renderer>(), attribs);
+    auto texture = wlr_texture_from_dmabuf(renderer->handle(), attribs);
     if (!texture)
         return nullptr;
     return new QWTexture(texture);
@@ -56,8 +53,7 @@ QWTexture *QWTexture::fromDmabuf(QWRenderer *renderer, wlr_dmabuf_attributes *at
 
 QWTexture *QWTexture::fromBuffer(QWRenderer *renderer, QWBuffer *buffer)
 {
-    auto texture = wlr_texture_from_buffer(renderer->handle<wlr_renderer>(),
-                                           buffer->handle<wlr_buffer>());
+    auto texture = wlr_texture_from_buffer(renderer->handle(), buffer->handle());
     if (!texture)
         return nullptr;
     return new QWTexture(texture);
@@ -71,7 +67,7 @@ QWTexture::~QWTexture()
 bool QWTexture::update(QWBuffer *buffer, pixman_region32 *damage)
 {
     Q_D(QWTexture);
-    return wlr_texture_update_from_buffer(d->handle(), buffer->handle<wlr_buffer>(), damage);
+    return wlr_texture_update_from_buffer(handle(), buffer->handle(), damage);
 }
 
 QW_END_NAMESPACE

--- a/src/render/qwtexture.h
+++ b/src/render/qwtexture.h
@@ -6,6 +6,7 @@
 #include <qwglobal.h>
 
 struct pixman_region32;
+struct wlr_texture;
 struct wlr_dmabuf_attributes;
 
 QW_BEGIN_NAMESPACE
@@ -18,16 +19,19 @@ class QW_EXPORT QWTexture : public QWObject
 {
     QW_DECLARE_PRIVATE(QWTexture)
 public:
+    explicit QWTexture(wlr_texture *handle);
+    ~QWTexture();
+
+    inline wlr_texture *handle() const {
+        return QWObject::handle<wlr_texture>();
+    }
+
     static QWTexture *fromPixels(QWRenderer *renderer, uint32_t fmt, uint32_t stride,
                                  uint32_t width, uint32_t height, const void *data);
     static QWTexture *fromDmabuf(QWRenderer *renderer, wlr_dmabuf_attributes *attribs);
     static QWTexture *fromBuffer(QWRenderer *renderer, QWBuffer *buffer);
 
-    ~QWTexture();
     bool update(QWBuffer *buffer, pixman_region32 *damage);
-
-private:
-    QWTexture(void *handle);
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwbuffer.cpp
+++ b/src/types/qwbuffer.cpp
@@ -19,11 +19,7 @@ public:
 
     }
     ~QWBufferPrivate() {
-        wlr_buffer_drop(handle());
-    }
-
-    inline wlr_buffer *handle() const {
-        return q_func()->handle<wlr_buffer>();
+        wlr_buffer_drop(q_func()->handle());
     }
 
     QW_DECLARE_PUBLIC(QWBuffer)
@@ -42,7 +38,7 @@ bool QWBuffer::isBuffer(wl_resource *resource)
     return wlr_resource_is_buffer(resource);
 }
 
-QWBuffer::QWBuffer(void *handle, QObject *parent)
+QWBuffer::QWBuffer(wlr_buffer *handle, QObject *parent)
     : QWObject(*new QWBufferPrivate(handle, this))
     , QObject(parent)
 {
@@ -52,56 +48,56 @@ QWBuffer::QWBuffer(void *handle, QObject *parent)
 void QWBuffer::drop()
 {
     Q_D(QWBuffer);
-    wlr_buffer_drop(d->handle());
+    wlr_buffer_drop(handle());
 }
 
 void QWBuffer::lock()
 {
     Q_D(QWBuffer);
-    wlr_buffer_lock(d->handle());
+    wlr_buffer_lock(handle());
 }
 
 void QWBuffer::unlock()
 {
     Q_D(QWBuffer);
-    wlr_buffer_unlock(d->handle());
+    wlr_buffer_unlock(handle());
 }
 
 bool QWBuffer::getDmabuf(wlr_dmabuf_attributes *attribs) const
 {
     Q_D(const QWBuffer);
-    return wlr_buffer_get_dmabuf(d->handle(), attribs);
+    return wlr_buffer_get_dmabuf(handle(), attribs);
 }
 
 bool QWBuffer::getShm(wlr_shm_attributes *attribs) const
 {
     Q_D(const QWBuffer);
-    return wlr_buffer_get_shm(d->handle(), attribs);
+    return wlr_buffer_get_shm(handle(), attribs);
 }
 
 void QWBuffer::beginDataPtrAccess(uint32_t flags, void **data,
                                   uint32_t *format, size_t *stride)
 {
     Q_D(QWBuffer);
-    wlr_buffer_begin_data_ptr_access(d->handle(), flags, data, format, stride);
+    wlr_buffer_begin_data_ptr_access(handle(), flags, data, format, stride);
 }
 
 void QWBuffer::endDataPtrAccess()
 {
     Q_D(QWBuffer);
-    wlr_buffer_end_data_ptr_access(d->handle());
+    wlr_buffer_end_data_ptr_access(handle());
 }
 
 wlr_client_buffer *QWBuffer::clientBufferCreate(const QWRenderer *renderer)
 {
     Q_D(QWBuffer);
-    return wlr_client_buffer_create(d->handle(), renderer->handle<wlr_renderer>());
+    return wlr_client_buffer_create(handle(), renderer->handle());
 }
 
 wlr_client_buffer *QWBuffer::clientBufferGet() const
 {
     Q_D(const QWBuffer);
-    return wlr_client_buffer_get(d->handle());
+    return wlr_client_buffer_get(handle());
 }
 
 bool QWBuffer::clientBufferApplyDamage(wlr_client_buffer *buffer, wlr_buffer *next,

--- a/src/types/qwbuffer.h
+++ b/src/types/qwbuffer.h
@@ -6,6 +6,7 @@
 #include <qwglobal.h>
 #include <QObject>
 
+struct wlr_buffer;
 struct wlr_dmabuf_attributes;
 struct wlr_shm_attributes;
 struct wlr_client_buffer;
@@ -17,14 +18,18 @@ QW_BEGIN_NAMESPACE
 
 class QWRenderer;
 class QWBufferPrivate;
-class QW_EXPORT QWBuffer : public QWObject, public QObject
+class QW_EXPORT QWBuffer : public QObject, public QWObject
 {
     QW_DECLARE_PRIVATE(QWBuffer)
 public:
+    explicit QWBuffer(wlr_buffer *handle, QObject *parent = nullptr);
+
     static QWBuffer *fromResource(wl_resource *resource, QObject *parent = nullptr);
     static bool isBuffer(wl_resource *resource);
 
-    explicit QWBuffer(void *handle, QObject *parent = nullptr);
+    inline wlr_buffer *handle() const {
+        return QWObject::handle<wlr_buffer>();
+    }
 
     void drop();
     void lock();


### PR DESCRIPTION
Allows to directly  to construct a QW* object by a wlr_* object,  it is more flexible for the developer of qwlroots, he can use qwlroots in part of the code, and use wlroots directly in another part of the code, for example:

// wlroots part, or the wlr_backend object is from another library struct wlr_backend *backend = wlr_multi_backend_create(display); ...
// qwlroots part
auto qbackend = new QWBackend(backend);

Other, move the QW*Private::handle to QW*::handle.