### PR TITLE
Add fedora/opensuse in obs workflows

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -14,6 +14,21 @@ test_build:
                 target_repository: Arch
             architectures:
               - x86_64
+        repositories:
+          - name: Fedora_Rawhide
+            paths:
+              - target_project: home:rewine:vioken
+                target_repository: Fedora_Rawhide
+            architectures:
+              - x86_64
+        repositories:
+          - name: openSUSE_Tumbleweed
+            paths:
+              - target_project: home:rewine:vioken
+                target_repository: openSUSE_Tumbleweed
+            architectures:
+              - x86_64
+              - aarch64
   filters:
     event: pull_request
 


### PR DESCRIPTION
openSUSE  failed in rpm_lint, we need set SONAME for libqwlroots.so