### PR TITLE
Fix interface/qwbackendinterface.h: No such file or directory

### DIFF
--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -9,22 +9,22 @@
 
 #include <qwbackend.h>
 #include <qwdisplay.h>
-#include <util/qwsignalconnector.h>
-#include <render/qwrenderer.h>
-#include <render/qwallocator.h>
-#include <types/qwcompositor.h>
-#include <types/qwsubcompositor.h>
-#include <types/qwdatadevice.h>
-#include <types/qwoutputlayout.h>
-#include <types/qwoutput.h>
-#include <types/qwscene.h>
-#include <types/qwseat.h>
-#include <types/qwxdgshell.h>
-#include <types/qwcursor.h>
-#include <types/qwxcursormanager.h>
-#include <types/qwinputdevice.h>
-#include <types/qwkeyboard.h>
-#include <types/qwpointer.h>
+#include <qwsignalconnector.h>
+#include <qwrenderer.h>
+#include <qwallocator.h>
+#include <qwcompositor.h>
+#include <qwsubcompositor.h>
+#include <qwdatadevice.h>
+#include <qwoutputlayout.h>
+#include <qwoutput.h>
+#include <qwscene.h>
+#include <qwseat.h>
+#include <qwxdgshell.h>
+#include <qwcursor.h>
+#include <qwxcursormanager.h>
+#include <qwinputdevice.h>
+#include <qwkeyboard.h>
+#include <qwpointer.h>
 
 #define WLR_USE_UNSTABLE
 extern "C" {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,10 @@ target_include_directories(${TARGET}
 target_include_directories(${TARGET}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/render>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/types>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/util>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interfaces>
 )
 
 target_include_directories(${TARGET}

--- a/src/interfaces/qwbackendinterface.h
+++ b/src/interfaces/qwbackendinterface.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <interfaces/qwinterface.h>
+#include <qwinterface.h>
 
 struct wlr_backend;
 struct wlr_backend_impl;

--- a/src/interfaces/qwoutputinterface.h
+++ b/src/interfaces/qwoutputinterface.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <interfaces/qwinterface.h>
+#include <qwinterface.h>
 #include <QPoint>
 
 struct wlr_output;

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
-#include <interfaces/qwbackendinterface.h>
+#include <qwbackendinterface.h>
 
 #include <QObject>
 #include <type_traits>

--- a/src/types/qwinputdevice.cpp
+++ b/src/types/qwinputdevice.cpp
@@ -6,7 +6,7 @@
 #include "qwkeyboard.h"
 #include "qwpointer.h"
 #include "qwtablet.h"
-#include "qwtabletpad.h""
+#include "qwtabletpad.h"
 
 extern "C" {
 #include <wlr/types/wlr_input_device.h>

--- a/src/types/qwkeyboard.h
+++ b/src/types/qwkeyboard.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
-#include <types/qwinputdevice.h>
+#include <qwinputdevice.h>
 #include <QObject>
 
 struct wlr_keyboard;

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
-#include <interfaces/qwoutputinterface.h>
+#include <qwoutputinterface.h>
 
 #include <QObject>
 #include <type_traits>

--- a/src/types/qwpointer.h
+++ b/src/types/qwpointer.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
-#include <types/qwinputdevice.h>
+#include <qwinputdevice.h>
 #include <QObject>
 
 struct wlr_pointer;

--- a/src/types/qwtablet.h
+++ b/src/types/qwtablet.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
-#include <types/qwinputdevice.h>
+#include <qwinputdevice.h>
 #include <QObject>
 
 struct wlr_tablet;

--- a/src/types/qwtabletpad.h
+++ b/src/types/qwtabletpad.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
-#include <types/qwinputdevice.h>
+#include <qwinputdevice.h>
 #include <QObject>
 
 struct wlr_tablet_pad;


### PR DESCRIPTION
When using QWlroots from system by find_package(QWlroots), because the "interface" directory is not install to system, so the project build failed.