### PR TITLE
Fix crash 'double free'

### DIFF
--- a/src/render/qwtexture.cpp
+++ b/src/render/qwtexture.cpp
@@ -13,7 +13,7 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-QWTexture::~QWTexture()
+void QWTexture::destroy()
 {
     wlr_texture_destroy(handle());
 }

--- a/src/render/qwtexture.h
+++ b/src/render/qwtexture.h
@@ -17,8 +17,7 @@ class QWBuffer;
 class QW_EXPORT QWTexture
 {
 public:
-    ~QWTexture();
-
+    void destroy();
     wlr_texture *handle() const;
 
     static QWTexture *from(wlr_texture *handle);
@@ -32,6 +31,7 @@ public:
 
 private:
     QWTexture() = default;
+    ~QWTexture() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwcursor.cpp
+++ b/src/types/qwcursor.cpp
@@ -245,7 +245,7 @@ void QWCursor::warpAbsolute(QWInputDevice *dev, const QPointF &pos)
 
 void QWCursor::move(QWInputDevice *dev, const QPointF &deltaPos)
 {
-    wlr_cursor_move(handle(), dev->handle(), deltaPos.x(), deltaPos.y());
+    wlr_cursor_move(handle(), dev ? dev->handle() : nullptr, deltaPos.x(), deltaPos.y());
 }
 
 void QWCursor::setImage(const QImage &image, const QPoint &hotspot)

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -311,7 +311,7 @@ const wlr_drm_format_set *QWOutput::getPrimaryFormats(uint32_t bufferCaps)
     return wlr_output_get_primary_formats(handle(), bufferCaps);
 }
 
-QWOutputCursor::~QWOutputCursor()
+void QWOutputCursor::destroy()
 {
     wlr_output_cursor_destroy(handle());
 }

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -109,7 +109,7 @@ private:
 class QW_EXPORT QWOutputCursor
 {
 public:
-    ~QWOutputCursor();
+    void destroy();
     wlr_output_cursor *handle() const;
 
     static QWOutputCursor *from(wlr_output_cursor *handle);
@@ -122,6 +122,7 @@ public:
 
 private:
     QWOutputCursor() = default;
+    ~QWOutputCursor() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwxcursormanager.cpp
+++ b/src/types/qwxcursormanager.cpp
@@ -11,7 +11,7 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-QWXCursorManager::~QWXCursorManager()
+void QWXCursorManager::destroy()
 {
     wlr_xcursor_manager_destroy(handle());
 }

--- a/src/types/qwxcursormanager.h
+++ b/src/types/qwxcursormanager.h
@@ -14,7 +14,7 @@ class QWCursor;
 class QW_EXPORT QWXCursorManager
 {
 public:
-    ~QWXCursorManager();
+    void destroy();
     wlr_xcursor_manager *handle() const;
 
     static QWXCursorManager *from(wlr_xcursor_manager *handle);
@@ -26,6 +26,7 @@ public:
 
 private:
     QWXCursorManager() = default;
+    ~QWXCursorManager() = default;
 };
 
 QW_END_NAMESPACE


### PR DESCRIPTION
The "delete" behovior in C++ will destroy the pointer(first destroy), and the destruct function of class will call the "wlr_xxxx_destroy" function(second destroy) to destroy the pointer. So, we can't using C++ style API to destroy the wlr_xxxx pointer.

Add the "destroy" function to class and mark the destruct function of class to private.

Allow the "dev" is nullptr in QWCursor::move.