### PR TITLE
Add beforeDestroy signals

### DIFF
--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -44,6 +44,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -57,6 +57,7 @@ public Q_SLOTS:
     bool start();
 
 Q_SIGNALS:
+    void beforeDestroy(QWBackend *self);
     void newInput(QWInputDevice *device);
     void newOutput(QWOutput *output);
 

--- a/src/qwdisplay.cpp
+++ b/src/qwdisplay.cpp
@@ -20,6 +20,8 @@ public:
 
     }
     ~QWDisplayPrivate() {
+        Q_EMIT q_func()->beforeDestroy(q_func());
+
         sc.invalidate();
         Q_ASSERT(isHandleOwner);
         if (m_handle) {
@@ -28,8 +30,6 @@ public:
             wl_display_destroy(display);
         }
     }
-
-    void on_destroy(void *);
 
     QW_DECLARE_PUBLIC(QWDisplay)
     QWSignalConnector sc;

--- a/src/qwdisplay.h
+++ b/src/qwdisplay.h
@@ -33,6 +33,9 @@ public:
     void exec();
     void start(QThread *thread);
 
+Q_SIGNALS:
+    void beforeDestroy(QWDisplay *self);
+
 public Q_SLOTS:
     void terminate();
 };

--- a/src/qwglobal.h
+++ b/src/qwglobal.h
@@ -55,6 +55,9 @@ public:
     }
 
     virtual ~QWObject();
+    inline bool isValid() const {
+        return qw_d_ptr->m_handle;
+    }
 
 protected:
     QWObject(QWObjectPrivate &dd);

--- a/src/render/qwallocator.cpp
+++ b/src/render/qwallocator.cpp
@@ -35,6 +35,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/render/qwallocator.h
+++ b/src/render/qwallocator.h
@@ -17,6 +17,7 @@ class QWRenderer;
 class QWAllocatorPrivate;
 class QW_EXPORT QWAllocator : public QObject, public QWObject
 {
+    Q_OBJECT
     QW_DECLARE_PRIVATE(QWAllocator)
 public:
     inline wlr_allocator *handle() {
@@ -28,6 +29,9 @@ public:
     static QWAllocator *from(wlr_allocator *handle);
 
     wlr_buffer *createBuffer(int width, int height, const wlr_drm_format *format);
+
+Q_SIGNALS:
+    void beforeDestroy(QWAllocator *self);
 
 private:
     QWAllocator(wlr_allocator *handle, bool isOwner);

--- a/src/render/qwrenderer.cpp
+++ b/src/render/qwrenderer.cpp
@@ -44,6 +44,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/render/qwrenderer.h
+++ b/src/render/qwrenderer.h
@@ -22,6 +22,7 @@ class QWTexture;
 class QWRendererPrivate;
 class QW_EXPORT QWRenderer : public QObject, public QWObject
 {
+    Q_OBJECT
     QW_DECLARE_PRIVATE(QWRenderer)
 public:
     inline wlr_renderer *handle() const {
@@ -56,6 +57,9 @@ public:
     bool readPixels(uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
                     uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data) const;
     int getDrmFd() const;
+
+Q_SIGNALS:
+    void beforeDestroy(QWRenderer *self);
 
 private:
     QWRenderer(wlr_renderer *handle, bool isOwner);

--- a/src/types/qwbuffer.cpp
+++ b/src/types/qwbuffer.cpp
@@ -35,6 +35,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwbuffer.h
+++ b/src/types/qwbuffer.h
@@ -49,6 +49,7 @@ public:
                                  pixman_region32 *damage);
 
 Q_SIGNALS:
+    void beforeDestroy(QWBuffer *self);
     void release();
 
 private:

--- a/src/types/qwcompositor.h
+++ b/src/types/qwcompositor.h
@@ -29,6 +29,7 @@ public:
     static QWCompositor *create(QWDisplay *display, QWRenderer *renderer);
 
 Q_SIGNALS:
+    void beforeDestroy(QWCompositor *self);
     // TODO: make to QWSurface
     void newSurface(wlr_surface *surface);
 

--- a/src/types/qwcursor.cpp
+++ b/src/types/qwcursor.cpp
@@ -59,6 +59,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwcursor.h
+++ b/src/types/qwcursor.h
@@ -70,6 +70,7 @@ public:
     QPointF position() const;
 
 Q_SIGNALS:
+    void beforeDestroy(QWCursor *self);
     void motion(wlr_pointer_motion_event *event);
     void motionAbsolute(wlr_pointer_motion_absolute_event *event);
     void button(wlr_pointer_button_event *event);

--- a/src/types/qwdatadevice.cpp
+++ b/src/types/qwdatadevice.cpp
@@ -34,6 +34,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwdatadevice.h
+++ b/src/types/qwdatadevice.h
@@ -15,6 +15,7 @@ class QWDisplay;
 class QWDataDeviceManagerPrivate;
 class QW_EXPORT QWDataDeviceManager : public QObject, public QWObject
 {
+    Q_OBJECT
     QW_DECLARE_PRIVATE(QWDataDeviceManager)
 public:
     inline wlr_data_device_manager *handle() const {
@@ -24,6 +25,9 @@ public:
     static QWDataDeviceManager *get(wlr_data_device_manager *handle);
     static QWDataDeviceManager *from(wlr_data_device_manager *handle);
     static QWDataDeviceManager *create(QWDisplay *display);
+
+Q_SIGNALS:
+    void beforeDestroy(QWDataDeviceManager *self);
 
 private:
     QWDataDeviceManager(wlr_data_device_manager *handle, bool isOwner);

--- a/src/types/qwinputdevice.cpp
+++ b/src/types/qwinputdevice.cpp
@@ -32,6 +32,7 @@ QWInputDevicePrivate::~QWInputDevicePrivate()
 void QWInputDevicePrivate::destroy() {
     Q_ASSERT(m_handle);
     Q_ASSERT(map.contains(m_handle));
+    Q_EMIT q_func()->beforeDestroy(q_func());
     map.remove(m_handle);
     sc.invalidate();
 }

--- a/src/types/qwinputdevice.h
+++ b/src/types/qwinputdevice.h
@@ -23,6 +23,9 @@ public:
     static QWInputDevice *get(wlr_input_device *handle);
     static QWInputDevice *from(wlr_input_device *handle);
 
+Q_SIGNALS:
+    void beforeDestroy(QWInputDevice *self);
+
 protected:
     QWInputDevice(QWObjectPrivate &dd);
     virtual ~QWInputDevice() override = default;

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -45,6 +45,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -92,6 +92,7 @@ public:
     const wlr_drm_format_set *getPrimaryFormats(uint32_t bufferCaps);
 
 Q_SIGNALS:
+    void beforeDestroy(QWOutput *self);
     void frame();
     void damage(wlr_output_event_damage *event);
     void needsFrame();

--- a/src/types/qwoutputlayout.cpp
+++ b/src/types/qwoutputlayout.cpp
@@ -38,6 +38,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwoutputlayout.h
+++ b/src/types/qwoutputlayout.h
@@ -46,6 +46,7 @@ public:
     QRect getBox(wlr_output *reference) const;
 
 Q_SIGNALS:
+    void beforeDestroy(QWOutputLayout *self);
     // TODO: make to QWOutputLayoutOutput
     void add(wlr_output_layout_output *output);
     void change(wlr_output_layout_output *output);

--- a/src/types/qwscene.cpp
+++ b/src/types/qwscene.cpp
@@ -45,6 +45,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }
@@ -449,6 +450,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwscene.h
+++ b/src/types/qwscene.h
@@ -62,6 +62,9 @@ public:
     void forEachBuffer(wlr_scene_buffer_iterator_func_t iterator, void *userData) const;
     wlr_scene_node *at(const QPointF &lpos, QPointF *npos = nullptr) const;
 
+Q_SIGNALS:
+    void beforeDestroy(QWSceneNode *self);
+
 protected:
     QWSceneNode(QWSceneNodePrivate &dd);
     QWSceneNode(wlr_scene_node *handle, bool isOwner);
@@ -164,6 +167,7 @@ class QWOutput;
 class QWSceneOutputPrivate;
 class QW_EXPORT QWSceneOutput : public QObject, public QWObject
 {
+    Q_OBJECT
     QW_DECLARE_PRIVATE(QWSceneOutput)
 public:
     explicit QWSceneOutput(QWScene *scene, QWOutput *output);
@@ -180,6 +184,9 @@ public:
     void sendFrameDone(timespec *now);
 
     void forEachBuffer(wlr_scene_buffer_iterator_func_t iterator, void *user_data) const;
+
+Q_SIGNALS:
+    void beforeDestroy(QWSceneOutput *self);
 
 private:
     QWSceneOutput(wlr_scene_output *handle, bool isOwner);

--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -51,6 +51,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwseat.h
+++ b/src/types/qwseat.h
@@ -54,6 +54,7 @@ public:
     void pointerClearFocus();
 
 Q_SIGNALS:
+    void beforeDestroy(QWSeat *self);
     void pointerGrabBegin();
     void pointerGrabEnd();
     void keyboardGrabBegin();

--- a/src/types/qwsubcompositor.cpp
+++ b/src/types/qwsubcompositor.cpp
@@ -34,6 +34,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwsubcompositor.h
+++ b/src/types/qwsubcompositor.h
@@ -16,6 +16,7 @@ class QWDisplay;
 class QWSubcompositorPrivate;
 class QW_EXPORT QWSubcompositor : public QObject, public QWObject
 {
+    Q_OBJECT
     QW_DECLARE_PRIVATE(QWSubcompositor)
 public:
     inline wlr_subcompositor *handle() const {
@@ -25,6 +26,9 @@ public:
     static QWSubcompositor *get(wlr_subcompositor *handle);
     static QWSubcompositor *from(wlr_subcompositor *handle);
     static QWSubcompositor *create(QWDisplay *display);
+
+Q_SIGNALS:
+    void beforeDestroy(QWSubcompositor *self);
 
 private:
     QWSubcompositor(wlr_subcompositor *handle, bool isOwner);

--- a/src/types/qwxdgshell.cpp
+++ b/src/types/qwxdgshell.cpp
@@ -37,6 +37,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }
@@ -116,6 +117,7 @@ public:
     inline void destroy() {
         Q_ASSERT(m_handle);
         Q_ASSERT(map.contains(m_handle));
+        Q_EMIT q_func()->beforeDestroy(q_func());
         map.remove(m_handle);
         sc.invalidate();
     }

--- a/src/types/qwxdgshell.h
+++ b/src/types/qwxdgshell.h
@@ -40,6 +40,7 @@ public:
     static QWXdgShell *from(wlr_xdg_shell *handle);
 
 Q_SIGNALS:
+    void beforeDestroy(QWXdgShell *self);
     void newSurface(wlr_xdg_surface *surface);
 
 private:
@@ -76,6 +77,7 @@ public:
     void forEachPopupSurface(wlr_surface_iterator_func_t iterator, void *userData) const;
 
 Q_SIGNALS:
+    void beforeDestroy(QWXdgSurface *self);
     void pingTimeout();
     void newPopup(QWXdgPopup *popup);
     void map();


### PR DESCRIPTION
To notify before destroy handle(wlr_*), maybe the compositor needs to disconnect signals of the other QW* objects, avoid using the QW*::handle after the handle destroy.