### PR TITLE
Update flake and filter source code for nix derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <inxpkgs> { }, wlroots_0_17_src ? null }:
+{ pkgs ? import <inxpkgs> { }, wlroots_0_17_src ? null , nix-filter }:
 let
   mkDate = longDate: (pkgs.lib.concatStringsSep "-" [
     (builtins.substring 0 4 longDate)
@@ -7,7 +7,15 @@ let
   ]);
 in
 rec {
-  wlroots-git = pkgs.wlroots_0_16.overrideAttrs (
+  wlroots-git = (pkgs.wlroots_0_16.override {
+    wayland = pkgs.wayland.overrideAttrs ( old : {
+      version = "1.22.0";
+      src = pkgs.fetchurl {
+        url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.22.0/downloads/wayland-1.22.0.tar.xz";
+        hash = "sha256-FUCvHqaYpHHC2OnSiDMsfg/TYMjx0Sk267fny8JCWEI=";
+      };
+    });
+  }).overrideAttrs (
     old: {
       version =  mkDate (wlroots_0_17_src.lastModifiedDate or "19700101") + "_" + (wlroots_0_17_src.shortRev or "dirty");
       src = wlroots_0_17_src;
@@ -20,10 +28,12 @@ rec {
   );
 
   qwlroots-qt6 = pkgs.qt6.callPackage ./nix {
+    inherit nix-filter;
     wlroots = pkgs.wlroots_0_16;
   };
   
   qwlroots-qt5 = pkgs.libsForQt5.callPackage ./nix {
+    inherit nix-filter;
     wlroots = pkgs.wlroots_0_16;
   };
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -15,13 +18,28 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1681154353,
+        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678724065,
-        "narHash": "sha256-MjeRjunqfGTBGU401nxIjs7PC9PZZ1FBCZp/bRB3C2M=",
+        "lastModified": 1682535835,
+        "narHash": "sha256-DrCcsZId29H+mr7yviOfCZeJOnJ51MIWLX3qSwwSpLI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8afc8489dc96f29f69bec50fdc51e27883f89c1",
+        "rev": "d12fa94d29856187b1c80db4edf4588df986d217",
         "type": "github"
       },
       "original": {
@@ -34,19 +52,35 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "wlroots-unstable": "wlroots-unstable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "wlroots-unstable": {
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1678619376,
-        "narHash": "sha256-/CmfCG/NidxXZMwrInbTDJ3qIvNeic5oh5FVMmUlPrs=",
+        "lastModified": 1682436395,
+        "narHash": "sha256-GGEjkQO9m7YLYIXIXM76HWdhjg4Ye+oafOtyaFAYKI4=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "a3489f2c64d391240bfd190e1f4829cad618bac0",
+        "rev": "6830bfc17fd94709e2cdd4da0af989f102a26e59",
         "type": "gitlab"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     wlroots-unstable = {
@@ -11,7 +12,7 @@
     };
   };
 
-  outputs = { self, flake-utils, nixpkgs, wlroots-unstable }@input:
+  outputs = { self, flake-utils, nix-filter, nixpkgs, wlroots-unstable }@input:
     flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "riscv64-linux" ]
       (system:
         let
@@ -19,13 +20,12 @@
         in
         rec {
           packages = import ./default.nix {
-            inherit pkgs;
+            inherit pkgs nix-filter;
             wlroots_0_17_src = wlroots-unstable;
           };
 
           devShell = pkgs.mkShell { 
             nativeBuildInputs = packages.default.nativeBuildInputs ++ (with pkgs; [
-              # (weston.override { buildDemo = true; })
               wayland-utils
             ]);
             inherit (packages.default) buildInputs;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, nix-filter
 , fetchFromGitHub
 , cmake
 , pkg-config
@@ -20,7 +21,17 @@ stdenv.mkDerivation rec {
   pname = "qwlroots";
   version = "0.0.1";
 
-  src = ./..;
+  src = nix-filter.lib.filter {
+    root = ./..;
+
+    exclude = [
+      ".git"
+      "LICENSE"
+      "README.md"
+      "README.zh_CN.md"
+      (nix-filter.lib.matchExt "nix")
+    ];
+  };
 
   nativeBuildInputs = [
     cmake

--- a/src/types/qwcompositor.cpp
+++ b/src/types/qwcompositor.cpp
@@ -82,7 +82,11 @@ QWCompositor *QWCompositor::from(wlr_compositor *handle)
 
 QWCompositor *QWCompositor::create(QWDisplay *display, QWRenderer *renderer)
 {
+#if WLR_VERSION_MINOR > 16
+    auto compositor = wlr_compositor_create(display->handle(), 5, renderer->handle());
+#else
     auto compositor = wlr_compositor_create(display->handle(), renderer->handle());
+#endif
     if (!compositor)
         return nullptr;
     return new QWCompositor(compositor, true);


### PR DESCRIPTION
1. 升级 nix 构建依赖
2. 使用 nix-filter 过滤不参与构建的文件
3. 修复  qwlroots-qt6-wlroots-git 的构建