### PR TITLE
drop QWOutputCursor::setSurface

### DIFF
--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -340,11 +340,6 @@ bool QWOutputCursor::setImage(const QImage &image, const QPoint &hotspot)
                                        hotspot.x(), hotspot.y());
 }
 
-void QWOutputCursor::setSurface(wlr_surface *surface, const QPoint &hotspot)
-{
-    wlr_output_cursor_set_surface(handle(), surface, hotspot.x(), hotspot.y());
-}
-
 bool QWOutputCursor::setBuffer(QWBuffer *buffer, const QPoint &hotspot)
 {
     return wlr_output_cursor_set_buffer(handle(), buffer->handle(), hotspot.x(), hotspot.y());

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -120,7 +120,6 @@ public:
     static QWOutputCursor *create(QWOutput *output);
 
     bool setImage(const QImage &image, const QPoint &hotspot);
-    void setSurface(wlr_surface *surface, const QPoint &hotspot);
     bool setBuffer(QWBuffer *buffer, const QPoint &hotspot);
     bool move(const QPointF &pos);
 


### PR DESCRIPTION
The wlroots drop wlr_output_cursor_set_surface in
d933f5204b4723eeb64b3c734d4017067f11811b.