### PR TITLE
Check underlying type for c enum

### DIFF
--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -16,6 +16,10 @@ extern "C" {
 #include <wlr/types/wlr_pointer.h>
 }
 
+static_assert(std::is_same_v<wlr_axis_orientation_t, std::underlying_type_t<wlr_axis_orientation>>);
+static_assert(std::is_same_v<wlr_axis_source_t, std::underlying_type_t<wlr_axis_source>>);
+static_assert(std::is_same_v<wlr_button_state_t, std::underlying_type_t<wlr_button_state>>);
+
 QW_BEGIN_NAMESPACE
 
 class QWSeatPrivate : public QWObjectPrivate

--- a/src/types/qwseat.h
+++ b/src/types/qwseat.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <qwglobal.h>
 #include <QObject>
 
@@ -15,9 +16,9 @@ struct wlr_drag;
 struct wlr_data_source;
 struct wlr_keyboard_modifiers;
 
-typedef int wlr_axis_orientation_t;
-typedef int wlr_axis_source_t;
-typedef int wlr_button_state_t;
+typedef uint32_t wlr_axis_orientation_t;
+typedef uint32_t wlr_axis_source_t;
+typedef uint32_t wlr_button_state_t;
 
 QW_BEGIN_NAMESPACE
 


### PR DESCRIPTION
底层类型是 uint_32_t, 而不是 int， 但不幸的是，这仍不能用于前置声明