### PR TITLE
Check the public nature of destructors

### DIFF
--- a/src/types/qwbuffer.h
+++ b/src/types/qwbuffer.h
@@ -22,6 +22,8 @@ class QW_EXPORT QWBuffer : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWBuffer)
 public:
+    ~QWBuffer() = default;
+
     inline wlr_buffer *handle() const {
         return QWObject::handle<wlr_buffer>();
     }
@@ -54,7 +56,6 @@ Q_SIGNALS:
 
 private:
     QWBuffer(wlr_buffer *handle, bool isOwner);
-    ~QWBuffer() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwcursor.h
+++ b/src/types/qwcursor.h
@@ -42,6 +42,7 @@ class QW_EXPORT QWCursor : public QObject, public QWObject
     QW_DECLARE_PRIVATE(QWCursor)
 public:
     explicit QWCursor(QObject *parent = nullptr);
+    ~QWCursor() = default;
 
     inline wlr_cursor *handle() const {
         return QWObject::handle<wlr_cursor>();

--- a/src/types/qwdamagering.h
+++ b/src/types/qwdamagering.h
@@ -18,6 +18,9 @@ QW_BEGIN_NAMESPACE
 class QW_EXPORT QWDamageRing
 {
 public:
+    QWDamageRing() = delete;
+    ~QWDamageRing() = delete;
+
     wlr_damage_ring *handle() const;
 
     static QWDamageRing *from(wlr_damage_ring *handle);
@@ -29,10 +32,6 @@ public:
     void addWhole();
     void ringRotate();
     void getBufferDamage(int bufferAge, pixman_region32_t *damage) const;
-
-private:
-    QWDamageRing() = default;
-    ~QWDamageRing() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwforeigntoplevelhandlev1.h
+++ b/src/types/qwforeigntoplevelhandlev1.h
@@ -46,6 +46,8 @@ class QW_EXPORT QWForeignToplevelHandleV1 : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWForeignToplevelHandleV1)
 public:
+    ~QWForeignToplevelHandleV1() = default;
+
     inline wlr_foreign_toplevel_handle_v1 *handle() const {
         return QWObject::handle<wlr_foreign_toplevel_handle_v1>();
     }
@@ -75,7 +77,6 @@ Q_SIGNALS:
 
 private:
     QWForeignToplevelHandleV1(wlr_foreign_toplevel_handle_v1 *handle, bool isOwner);
-    ~QWForeignToplevelHandleV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwidle.h
+++ b/src/types/qwidle.h
@@ -44,6 +44,8 @@ class QW_EXPORT QWIdleTimeout : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWIdleTimeout)
 public:
+    ~QWIdleTimeout() = default;
+
     inline wlr_idle_timeout *handle() const {
         return QWObject::handle<wlr_idle_timeout>();
     }
@@ -59,7 +61,6 @@ Q_SIGNALS:
 
 private:
     QWIdleTimeout(wlr_idle_timeout *handle, bool isOwner);
-    ~QWIdleTimeout() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwidlenotifyv1.cpp
+++ b/src/types/qwidlenotifyv1.cpp
@@ -5,8 +5,6 @@
 #include "qwdisplay.h"
 #include "qwseat.h"
 
-#include <QHash>
-
 extern "C" {
 #include <wlr/types/wlr_idle_notify_v1.h>
 }

--- a/src/types/qwinputdevice.cpp
+++ b/src/types/qwinputdevice.cpp
@@ -83,9 +83,9 @@ QWInputDevice *QWInputDevice::from(wlr_input_device *handle)
     case WLR_INPUT_DEVICE_SWITCH:
         return QWSwitch::fromInputDevice(handle);
     default:
-        // TODO: After implementing other device types
-        // Here should not create QWInputDevice
-        return new QWInputDevice(handle, false);;
+        // Here is not reachable
+        qCritical("Unknow input device type!");
+        return nullptr;
     }
 }
 

--- a/src/types/qwinputinhibitmanager.h
+++ b/src/types/qwinputinhibitmanager.h
@@ -32,6 +32,7 @@ Q_SIGNALS:
 
 private:
     QWInputInhibitManager(wlr_input_inhibit_manager *handle, bool isOwner);
+    ~QWInputInhibitManager() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwinputmethodv2.h
+++ b/src/types/qwinputmethodv2.h
@@ -21,6 +21,8 @@ class QW_EXPORT QWInputMethodKeyboardGrabV2 : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputMethodKeyboardGrabV2)
 public:
+    ~QWInputMethodKeyboardGrabV2() = default;
+
     inline wlr_input_method_keyboard_grab_v2 *handle() const {
         return QWObject::handle<wlr_input_method_keyboard_grab_v2>();
     }
@@ -37,7 +39,6 @@ Q_SIGNALS:
 
 private:
     QWInputMethodKeyboardGrabV2(wlr_input_method_keyboard_grab_v2 *handle, bool isOwner);
-    ~QWInputMethodKeyboardGrabV2() = default;
 };
 
 class QWInputPopupSurfaceV2Private;

--- a/src/types/qwkeyboardgroup.h
+++ b/src/types/qwkeyboardgroup.h
@@ -19,6 +19,7 @@ class QW_EXPORT QWKeyboardGroup : public QObject, public QWObject
     QW_DECLARE_PRIVATE(QWKeyboardGroup)
 public:
     explicit QWKeyboardGroup(QObject *parent = nullptr);
+    ~QWKeyboardGroup() = default;
 
     inline wlr_keyboard_group *handle() const {
         return QWObject::handle<wlr_keyboard_group>();

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -318,9 +318,9 @@ const wlr_drm_format_set *QWOutput::getPrimaryFormats(uint32_t bufferCaps)
     return wlr_output_get_primary_formats(handle(), bufferCaps);
 }
 
-void QWOutputCursor::destroy()
+void QWOutputCursor::operator delete(QWOutputCursor *p, std::destroying_delete_t)
 {
-    wlr_output_cursor_destroy(handle());
+    wlr_output_cursor_destroy(p->handle());
 }
 
 wlr_output_cursor *QWOutputCursor::handle() const

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -39,6 +39,8 @@ class QW_EXPORT QWOutput : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWOutput)
 public:
+    ~QWOutput() = default;
+
     inline wlr_output *handle() const {
         return QWObject::handle<wlr_output>();
     }
@@ -106,13 +108,15 @@ Q_SIGNALS:
 
 private:
     QWOutput(wlr_output *handle, bool isOwner);
-    ~QWOutput() = default;
 };
 
 class QW_EXPORT QWOutputCursor
 {
 public:
-    void destroy();
+    QWOutputCursor() = delete;
+    ~QWOutputCursor() = delete;
+
+    void operator delete(QWOutputCursor *p, std::destroying_delete_t);
     wlr_output_cursor *handle() const;
 
     static QWOutputCursor *from(wlr_output_cursor *handle);
@@ -121,10 +125,6 @@ public:
     bool setImage(const QImage &image, const QPoint &hotspot);
     bool setBuffer(QWBuffer *buffer, const QPoint &hotspot);
     bool move(const QPointF &pos);
-
-private:
-    QWOutputCursor() = default;
-    ~QWOutputCursor() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwoutputlayout.h
+++ b/src/types/qwoutputlayout.h
@@ -22,6 +22,7 @@ class QW_EXPORT QWOutputLayout : public QObject, public QWObject
     QW_DECLARE_PRIVATE(QWOutputLayout)
 public:
     explicit QWOutputLayout(QObject *parent = nullptr);
+    ~QWOutputLayout() = default;
 
     inline wlr_output_layout *handle() const {
         return QWObject::handle<wlr_output_layout>();

--- a/src/types/qwpointerconstraintsv1.h
+++ b/src/types/qwpointerconstraintsv1.h
@@ -35,6 +35,7 @@ Q_SIGNALS:
 
 private:
     QWPointerConstraintV1(wlr_pointer_constraint_v1 *handle, bool isOwner);
+    ~QWPointerConstraintV1() = default;
 };
 
 class QWSeat;
@@ -62,6 +63,7 @@ Q_SIGNALS:
 
 private:
     QWPointerConstraintsV1(wlr_pointer_constraints_v1 *handle, bool isOwner);
+    ~QWPointerConstraintsV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwpointergesturesv1.h
+++ b/src/types/qwpointergesturesv1.h
@@ -40,6 +40,7 @@ Q_SIGNALS:
 
 private:
     QWPointerGesturesV1(wlr_pointer_gestures_v1 *handle, bool isOwner);
+    ~QWPointerGesturesV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwprimaryselection.h
+++ b/src/types/qwprimaryselection.h
@@ -19,6 +19,8 @@ class QW_EXPORT QWPrimarySelectionSource : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPrimarySelectionSource)
 public:
+    ~QWPrimarySelectionSource() = default;
+
     inline wlr_primary_selection_source *handle() const {
         return QWObject::handle<wlr_primary_selection_source>();
     }

--- a/src/types/qwprimaryselectionv1.h
+++ b/src/types/qwprimaryselectionv1.h
@@ -30,6 +30,7 @@ Q_SIGNALS:
 
 private:
     QWPrimarySelectionV1DeviceManager(wlr_primary_selection_v1_device_manager *handle, bool isOwner);
+    ~QWPrimarySelectionV1DeviceManager() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwrelativepointerv1.h
+++ b/src/types/qwrelativepointerv1.h
@@ -30,6 +30,7 @@ Q_SIGNALS:
 
 private:
     QWRelativeV1(wlr_relative_pointer_v1 *handle, bool isOwner);
+    ~QWRelativeV1() = default;
 };
 
 class QWSeat;
@@ -55,6 +56,7 @@ Q_SIGNALS:
 
 private:
     QWRelativeManagerV1(wlr_relative_pointer_manager_v1 *handle, bool isOwner);
+    ~QWRelativeManagerV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwscene.cpp
+++ b/src/types/qwscene.cpp
@@ -16,7 +16,7 @@
 
 extern "C" {
 // avoid replace static
-#include <wayland-server-core.h>
+#include <math.h>
 #define static
 #include <wlr/types/wlr_scene.h>
 #undef static

--- a/src/types/qwscene.h
+++ b/src/types/qwscene.h
@@ -46,6 +46,8 @@ class QW_EXPORT QWSceneNode : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSceneNode)
 public:
+    virtual ~QWSceneNode() override = default;
+
     inline wlr_scene_node *handle() const {
         return QWObject::handle<wlr_scene_node>();
     }
@@ -76,6 +78,7 @@ class QW_EXPORT QWSceneTree : public QWSceneNode
 {
     Q_OBJECT
 public:
+    ~QWSceneTree() override = default;
     explicit QWSceneTree(QWSceneTree *parent);
 
     wlr_scene_tree *handle() const;
@@ -97,6 +100,7 @@ class QW_EXPORT QWScene : public QWSceneTree
 {
     Q_OBJECT
 public:
+    ~QWScene() override = default;
     explicit QWScene(QObject *parent = nullptr);
 
     wlr_scene *handle() const;
@@ -118,6 +122,7 @@ class QW_EXPORT QWSceneBuffer : public QWSceneNode
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSceneBuffer)
 public:
+    ~QWSceneBuffer() override = default;
     explicit QWSceneBuffer(QWBuffer *buffer, QWSceneTree *parent);
 
     wlr_scene_buffer *handle() const;
@@ -148,6 +153,7 @@ class QW_EXPORT QWSceneRect : public QWSceneNode
 {
     Q_OBJECT
 public:
+    ~QWSceneRect() override = default;
     explicit QWSceneRect(const QSize &size, const QColor &color, QWSceneTree *parent);
 
     inline wlr_scene_rect *handle() const {
@@ -172,6 +178,7 @@ class QW_EXPORT QWSceneOutput : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSceneOutput)
 public:
+    ~QWSceneOutput() override = default;
     explicit QWSceneOutput(QWScene *scene, QWOutput *output);
 
     inline wlr_scene_output *handle() const {
@@ -192,7 +199,6 @@ Q_SIGNALS:
 
 private:
     QWSceneOutput(wlr_scene_output *handle, bool isOwner);
-    ~QWSceneOutput() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwscreencopyv1.h
+++ b/src/types/qwscreencopyv1.h
@@ -30,6 +30,7 @@ Q_SIGNALS:
 
 private:
     QWScreenCopyManagerV1(wlr_screencopy_manager_v1 *handle, bool isOwner);
+    ~QWScreenCopyManagerV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -169,15 +169,6 @@ QWSeat::QWSeat(wlr_seat *handle, bool isOwner)
 
 }
 
-QWSeat *QWSeat::create(QWDisplay *display, const char *name)
-{
-    auto handle = wlr_seat_create(display->handle(), name);
-    if (!handle)
-        return nullptr;
-    return new QWSeat(handle, true);
-}
-
-
 QWSeat *QWSeat::get(wlr_seat *handle)
 {
     return QWSeatPrivate::map.value(handle);
@@ -185,9 +176,17 @@ QWSeat *QWSeat::get(wlr_seat *handle)
 
 QWSeat *QWSeat::from(wlr_seat *handle)
 {
-    if (auto o = get(handle))
+    if (auto *o = get(handle))
         return o;
     return new QWSeat(handle, false);
+}
+
+QWSeat *QWSeat::create(QWDisplay *display, const char *name)
+{
+    auto *handle = wlr_seat_create(display->handle(), name);
+    if (!handle)
+        return nullptr;
+    return new QWSeat(handle, true);
 }
 
 void QWSeat::setKeyboard(QWKeyboard *keyboard)

--- a/src/types/qwseat.h
+++ b/src/types/qwseat.h
@@ -31,7 +31,7 @@ class QW_EXPORT QWSeat : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSeat)
 public:
-    static QWSeat *create(QWDisplay *display, const char *name);
+    ~QWSeat() = default;
 
     inline wlr_seat *handle() const {
         return QWObject::handle<wlr_seat>();
@@ -39,6 +39,7 @@ public:
 
     static QWSeat *get(wlr_seat *handle);
     static QWSeat *from(wlr_seat *handle);
+    static QWSeat *create(QWDisplay *display, const char *name);
 
     void setKeyboard(QWKeyboard *keyboard);
     QWKeyboard *getKeyboard() const;
@@ -72,7 +73,6 @@ Q_SIGNALS:
 
 private:
     QWSeat(wlr_seat *handle, bool isOwner);
-    ~QWSeat() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwsessionlockv1.h
+++ b/src/types/qwsessionlockv1.h
@@ -34,6 +34,7 @@ Q_SIGNALS:
 
 private:
     QWSessionLockSurfaceV1(wlr_session_lock_surface_v1 *handle, bool isOwner);
+    ~QWSessionLockSurfaceV1() = default;
 };
 
 class QWSessionLockV1Private;
@@ -42,6 +43,8 @@ class QW_EXPORT QWSessionLockV1 : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSessionLockV1)
 public:
+    ~QWSessionLockV1() = default;
+
     inline wlr_session_lock_v1 *handle() const {
         return QWObject::handle<wlr_session_lock_v1>();
     }
@@ -81,6 +84,7 @@ Q_SIGNALS:
 
 private:
     QWSessionLockManagerV1(wlr_session_lock_manager_v1 *handle, bool isOwner);
+    ~QWSessionLockManagerV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwtabletmanagerv2.cpp
+++ b/src/types/qwtabletmanagerv2.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwtabletv2.h"
+#include "qwtablet.h"
 #include "util/qwsignalconnector.h"
 
 #include <qwinputdevice.h>
@@ -68,7 +69,7 @@ QWTabletManagerV2 *QWTabletManagerV2::get(wlr_tablet_manager_v2 *handle)
 
 QWTabletManagerV2 *QWTabletManagerV2::from(wlr_tablet_manager_v2 *handle)
 {
-    if (auto o = get(handle))
+    if (auto *o = get(handle))
         return o;
     return new QWTabletManagerV2(handle, false);
 }
@@ -82,19 +83,28 @@ QWTabletManagerV2 *QWTabletManagerV2::create(QWDisplay *display)
 QWTabletV2Tablet *QWTabletManagerV2::createTablet(QWSeat *wlr_seat, QWInputDevice *wlr_device)
 {
     auto *handle = wlr_tablet_create(this->handle(), wlr_seat->handle(), wlr_device->handle());
-    return handle ? new QWTabletV2Tablet(handle, true) : nullptr;
+    if (!handle)
+        return nullptr;
+    auto *parent = QWInputDevice::from(handle->wlr_device);
+    return new QWTabletV2Tablet(handle, true, parent);
 }
 
 QWTabletV2TabletPad *QWTabletManagerV2::createPad(QWSeat *wlr_seat, QWInputDevice *wlr_device)
 {
     auto *handle = wlr_tablet_pad_create(this->handle(), wlr_seat->handle(), wlr_device->handle());
-    return handle ? new QWTabletV2TabletPad(handle, true) : nullptr;
+    if (!handle)
+        return nullptr;
+    auto *parent = QWInputDevice::from(handle->wlr_device);
+    return new QWTabletV2TabletPad(handle, true, parent);
 }
 
 QWTabletV2TabletTool *QWTabletManagerV2::createTool(QWSeat *wlr_seat, wlr_tablet_tool *wlr_tool)
 {
     auto *handle = wlr_tablet_tool_create(this->handle(), wlr_seat->handle(), wlr_tool);
-    return handle ? new QWTabletV2TabletTool(handle, true) : nullptr;
+    if (!handle)
+        return nullptr;
+    auto *parent = QWTabletTool::from(handle->wlr_tool);
+    return new QWTabletV2TabletTool(handle, true, parent);
 }
 
 QW_END_NAMESPACE

--- a/src/types/qwtabletv2.h
+++ b/src/types/qwtabletv2.h
@@ -26,9 +26,13 @@ QT_END_NAMESPACE
 
 QW_BEGIN_NAMESPACE
 
+class QWInputDevice;
+class QWTabletTool;
 class QW_EXPORT QWTabletPadV2Grab
 {
 public:
+    QWTabletPadV2Grab() = delete;
+    ~QWTabletPadV2Grab() = delete;
     static QWTabletPadV2Grab *from(wlr_tablet_pad_v2_grab *handle);
     wlr_tablet_pad_v2_grab *handle() const;
 };
@@ -36,6 +40,8 @@ public:
 class QW_EXPORT QWTabletToolV2Grab
 {
 public:
+    QWTabletToolV2Grab() = delete;
+    ~QWTabletToolV2Grab() = delete;
     static QWTabletToolV2Grab *from(wlr_tablet_tool_v2_grab *handle);
     wlr_tablet_tool_v2_grab *handle() const;
 };
@@ -62,7 +68,8 @@ Q_SIGNALS:
     void beforeDestroy(QWTabletV2Tablet *self);
 
 private:
-    QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner);
+    explicit QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner, QWInputDevice *parent);
+    ~QWTabletV2Tablet() = default;
 };
 
 class QWSurface;
@@ -115,7 +122,8 @@ Q_SIGNALS:
     void setCursor(wlr_tablet_v2_event_cursor *);
 
 private:
-    QWTabletV2TabletTool(wlr_tablet_v2_tablet_tool *handle, bool isOwner);
+    QWTabletV2TabletTool(wlr_tablet_v2_tablet_tool *handle, bool isOwner, QWTabletTool *parent);
+    ~QWTabletV2TabletTool() = default;
 };
 
 class QWTabletV2TabletPadPrivate;
@@ -155,7 +163,8 @@ Q_SIGNALS:
     void stripFeedback(wlr_tablet_v2_event_feedback *);
 
 private:
-    QWTabletV2TabletPad(wlr_tablet_v2_tablet_pad *handle, bool isOwner);
+    QWTabletV2TabletPad(wlr_tablet_v2_tablet_pad *handle, bool isOwner, QWInputDevice *parent);
+    ~QWTabletV2TabletPad() = default;
 };
 
 class QWDisplay;
@@ -184,6 +193,7 @@ Q_SIGNALS:
 
 private:
     QWTabletManagerV2(wlr_tablet_manager_v2 *handle, bool isOwner);
+    ~QWTabletManagerV2() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwtabletv2tablepad.cpp
+++ b/src/types/qwtabletv2tablepad.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2023 Dingyuan Zhang <zhangdingyuan@uniontech.com>.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
+#include "qwinputdevice.h"
 #include "qwtabletv2.h"
 #include "util/qwsignalconnector.h"
 
@@ -64,8 +65,8 @@ void QWTabletV2TabletPadPrivate::on_strip_feedback(wlr_tablet_v2_event_feedback 
     Q_EMIT q_func()->stripFeedback(event);
 }
 
-QWTabletV2TabletPad::QWTabletV2TabletPad(wlr_tablet_v2_tablet_pad *handle, bool isOwner)
-    : QObject(nullptr)
+QWTabletV2TabletPad::QWTabletV2TabletPad(wlr_tablet_v2_tablet_pad *handle, bool isOwner, QWInputDevice *parent)
+    : QObject(parent)
     , QWObject(*new QWTabletV2TabletPadPrivate(handle, isOwner, this))
 {
 
@@ -80,7 +81,8 @@ QWTabletV2TabletPad *QWTabletV2TabletPad::from(wlr_tablet_v2_tablet_pad *handle)
 {
     if (auto o = get(handle))
         return o;
-    return new QWTabletV2TabletPad(handle, false);
+    auto *parent = QWInputDevice::from(handle->wlr_device);
+    return new QWTabletV2TabletPad(handle, false, parent);
 }
 
 uint32_t QWTabletV2TabletPad::sendEnter(QWTabletV2Tablet *tablet, QWSurface *surface)

--- a/src/types/qwtabletv2tablet.cpp
+++ b/src/types/qwtabletv2tablet.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwtabletv2.h"
+#include "qwinputdevice.h"
 #include "util/qwsignalconnector.h"
 
 #include <qwcompositor.h>
@@ -51,8 +52,8 @@ void QWTabletV2TabletPrivate::on_destroy(void *)
     delete q_func();
 }
 
-QWTabletV2Tablet::QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner)
-    : QObject(nullptr)
+QWTabletV2Tablet::QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner, QWInputDevice *parent)
+    : QObject(parent)
     , QWObject(*new QWTabletV2TabletPrivate(handle, isOwner, this))
 {
 }
@@ -64,9 +65,10 @@ QWTabletV2Tablet *QWTabletV2Tablet::get(wlr_tablet_v2_tablet *handle)
 
 QWTabletV2Tablet *QWTabletV2Tablet::from(wlr_tablet_v2_tablet *handle)
 {
-    if (auto o = get(handle))
+    if (auto *o = get(handle))
         return o;
-    return new QWTabletV2Tablet(handle, false);
+    auto *parent = QWInputDevice::from(handle->wlr_device);
+    return new QWTabletV2Tablet(handle, false, parent);
 }
 
 bool QWTabletV2Tablet::canAcceptTablet(QWSurface *surface) const

--- a/src/types/qwtabletv2tabletool.cpp
+++ b/src/types/qwtabletv2tabletool.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwtabletv2.h"
+#include "qwtablet.h"
 #include "util/qwsignalconnector.h"
 
 #include <qwcompositor.h>
@@ -48,8 +49,8 @@ public:
 };
 QHash<void*, QWTabletV2TabletTool*> QWTabletV2TabletToolPrivate::map;
 
-QWTabletV2TabletTool::QWTabletV2TabletTool(wlr_tablet_v2_tablet_tool *handle, bool isOwner)
-    : QObject(nullptr)
+QWTabletV2TabletTool::QWTabletV2TabletTool(wlr_tablet_v2_tablet_tool *handle, bool isOwner, QWTabletTool *parent)
+    : QObject(parent)
     , QWObject(*new QWTabletV2TabletToolPrivate(handle, isOwner, this))
 {
 
@@ -64,7 +65,8 @@ QWTabletV2TabletTool *QWTabletV2TabletTool::from(wlr_tablet_v2_tablet_tool *hand
 {
     if (auto o = get(handle))
         return o;
-    return new QWTabletV2TabletTool(handle, false);
+    auto *parent = QWTabletTool::from(handle->wlr_tool);
+    return new QWTabletV2TabletTool(handle, false, parent);
 }
 
 void QWTabletV2TabletTool::sendProximityIn(QWTabletV2Tablet *tablet, QWSurface *surface)

--- a/src/types/qwtextinputv3.h
+++ b/src/types/qwtextinputv3.h
@@ -43,6 +43,7 @@ Q_SIGNALS:
 
 private:
     QWTextInputV3(wlr_text_input_v3 *handle, bool isOwner);
+    ~QWTextInputV3() = default;
 };
 
 class QWTextInputManagerV3Private;
@@ -65,6 +66,7 @@ Q_SIGNALS:
 
 private:
     QWTextInputManagerV3(wlr_text_input_manager_v3 *handle, bool isOwner);
+    ~QWTextInputManagerV3() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwvirtualkeyboardv1.h
+++ b/src/types/qwvirtualkeyboardv1.h
@@ -44,6 +44,7 @@ Q_SIGNALS:
 
 private:
     QWVirtualKeyboardManagerV1(wlr_virtual_keyboard_manager_v1 *handle, bool isOwner);
+    ~QWVirtualKeyboardManagerV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwvirtualpointerv1.h
+++ b/src/types/qwvirtualpointerv1.h
@@ -32,6 +32,7 @@ Q_SIGNALS:
 
 private:
     QWVirtualPointerManagerV1(wlr_virtual_pointer_manager_v1 *handle, bool isOwner);
+    ~QWVirtualPointerManagerV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwxdgactivationv1.h
+++ b/src/types/qwxdgactivationv1.h
@@ -17,6 +17,8 @@ class QW_EXPORT QWXdgActivationTokenV1 : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgActivationTokenV1)
 public:
+    ~QWXdgActivationTokenV1() = default;
+
     inline wlr_xdg_activation_token_v1 *handle() const {
         return QWObject::handle<wlr_xdg_activation_token_v1>();
     }
@@ -61,6 +63,7 @@ Q_SIGNALS:
 
 private:
     QWXdgActivationV1(wlr_xdg_activation_v1 *handle, bool isOwner);
+    ~QWXdgActivationV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwxdgdecorationmanagerv1.h
+++ b/src/types/qwxdgdecorationmanagerv1.h
@@ -34,6 +34,7 @@ Q_SIGNALS:
 
 private:
     QWXdgDecorationManagerV1(wlr_xdg_decoration_manager_v1 *handle, bool isOwner);
+    ~QWXdgDecorationManagerV1() = default;
 };
 
 class QWXdgToplevelDecorationV1Private;
@@ -56,6 +57,7 @@ Q_SIGNALS:
 
 private:
     QWXdgToplevelDecorationV1(wlr_xdg_toplevel_decoration_v1 *handle, bool isOwner);
+    ~QWXdgToplevelDecorationV1() = default;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwxdgshell.h
+++ b/src/types/qwxdgshell.h
@@ -96,6 +96,8 @@ class QW_EXPORT QWXdgPopup : public QWXdgSurface
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgPopup)
 public:
+    ~QWXdgPopup() = default;
+
     wlr_xdg_popup *handle() const;
 
     static QWXdgPopup *get(wlr_xdg_popup *handle);
@@ -112,7 +114,6 @@ Q_SIGNALS:
 
 private:
     QWXdgPopup(wlr_xdg_popup *handle, bool isOwner);
-    ~QWXdgPopup() = default;
 };
 
 class QWXdgToplevelPrivate;

--- a/src/types/qwxwayland.cpp
+++ b/src/types/qwxwayland.cpp
@@ -3,6 +3,7 @@
 
 #include "qwxwayland.h"
 
+#include "qwxwaylandserver.h"
 #include "util/qwsignalconnector.h"
 #include <qwdisplay.h>
 #include <qwcompositor.h>
@@ -57,10 +58,13 @@ public:
 };
 QHash<void*, QWXWayland*> QWXWaylandPrivate::map;
 
-QWXWayland *QWXWayland::create(QWDisplay *wl_display, QWCompositor *compositor, bool lazy, QObject *parent)
+QWXWayland *QWXWayland::create(QWDisplay *wl_display, QWCompositor *compositor, bool lazy)
 {
     auto *handle = wlr_xwayland_create(wl_display->handle(), compositor->handle(), lazy);
-    return handle ? new QWXWayland(handle, true, parent) : nullptr;
+    if (!handle)
+        return nullptr;
+    auto *parent = QWXWaylandServer::from(handle->server);
+    return new QWXWayland(handle, true, parent);
 }
 
 QWXWayland *QWXWayland::get(wlr_xwayland *handle)
@@ -91,7 +95,7 @@ wlr_xwayland *QWXWayland::handle() const
     return QWObject::handle<wlr_xwayland>();
 }
 
-QWXWayland::QWXWayland(wlr_xwayland *handle, bool isOwner, QObject *parent)
+QWXWayland::QWXWayland(wlr_xwayland *handle, bool isOwner, QWXWaylandServer *parent)
     : QObject(parent)
     , QWObject(*new QWXWaylandPrivate(handle, isOwner, this))
 {

--- a/src/types/qwxwayland.h
+++ b/src/types/qwxwayland.h
@@ -15,16 +15,17 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWCompositor;
 class QWSeat;
+class QWXWaylandServer;
 class QWXWaylandPrivate;
 class QW_EXPORT QWXWayland : public QObject, public QWObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXWayland)
 public:
-    explicit QWXWayland(wlr_xwayland *handle, bool isOwner = false, QObject *parent = nullptr);
+    explicit QWXWayland(wlr_xwayland *handle, bool isOwner, QWXWaylandServer *parent);
     ~QWXWayland() = default;
 
-    static QWXWayland *create(QWDisplay *display, QWCompositor *compositor, bool lazy, QObject *parent = nullptr);
+    static QWXWayland *create(QWDisplay *display, QWCompositor *compositor, bool lazy);
     static QWXWayland *get(wlr_xwayland *handle);
     wlr_xwayland *handle() const;
 

--- a/src/types/qwxwaylandshellv1.cpp
+++ b/src/types/qwxwaylandshellv1.cpp
@@ -55,10 +55,12 @@ QWXWaylandShellV1* QWXWaylandShellV1::get(wlr_xwayland_shell_v1* handle)
     return QWXWaylandShellV1Private::map.value(handle);
 }
 
-QWXWaylandShellV1* QWXWaylandShellV1::create(QWDisplay* display, uint32_t version, QObject* parent)
+QWXWaylandShellV1* QWXWaylandShellV1::create(QWDisplay* display, uint32_t version)
 {
     auto* handle = wlr_xwayland_shell_v1_create(display->handle(), version);
-    return handle ? new QWXWaylandShellV1(handle, true, parent) : nullptr;
+    if (!handle)
+        return nullptr;
+    return new QWXWaylandShellV1(handle, true, display);
 }
 
 wlr_xwayland_shell_v1* QWXWaylandShellV1::handle() const
@@ -77,7 +79,7 @@ QWSurface *QWXWaylandShellV1::surfaceFromSerial(uint64_t serial) const
     return surface ? QWSurface::from(surface) : nullptr;
 }
 
-QWXWaylandShellV1::QWXWaylandShellV1(wlr_xwayland_shell_v1* handle, bool isOwner, QObject* parent)
+QWXWaylandShellV1::QWXWaylandShellV1(wlr_xwayland_shell_v1* handle, bool isOwner, QWDisplay* parent)
     : QObject(parent)
     , QWObject(*new QWXWaylandShellV1Private(handle, isOwner, this))
 {

--- a/src/types/qwxwaylandshellv1.h
+++ b/src/types/qwxwaylandshellv1.h
@@ -26,10 +26,10 @@ class QW_EXPORT QWXWaylandShellV1 : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXWaylandShellV1)
 public:
-    QWXWaylandShellV1(wlr_xwayland_shell_v1 *handle, bool isOwner = false, QObject *parent = nullptr);
+    explicit QWXWaylandShellV1(wlr_xwayland_shell_v1 *handle, bool isOwner, QWDisplay *parent);
     ~QWXWaylandShellV1() = default;
 
-    static QWXWaylandShellV1 *create(QWDisplay *display, uint32_t version, QObject *parent = nullptr);
+    static QWXWaylandShellV1 *create(QWDisplay *display, uint32_t version);
     static QWXWaylandShellV1 *get(wlr_xwayland_shell_v1 *handle);
 
     wlr_xwayland_shell_v1 *handle() const;

--- a/src/types/qwxwaylandsurface.h
+++ b/src/types/qwxwaylandsurface.h
@@ -17,6 +17,9 @@ QW_BEGIN_NAMESPACE
 class QWSurface;
 class QWXWaylandSurface {
 public:
+    QWXWaylandSurface() = delete;
+    ~QWXWaylandSurface() = delete;
+
     static QWXWaylandSurface* from(wlr_xwayland_surface* surface);
 #if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
     static QWXWaylandSurface *tryFromWlrSurface(QWSurface *surface);


### PR DESCRIPTION
Make sure the destructor is public when wlroots provides wlr_xxx_destroy

The destructor is private, when wlroots provides the destroy signal and does not expose the wlr_xxx_destroy function

Set the QObject parent, when wlroots does not provide a destroy signal but listens to the parent's destroy signal and destroys itself accordingly