### PR TITLE
QWXdgToplevel::setParsent to QWXdgToplevel::setParent

### DIFF
--- a/src/types/qwxdgshell.cpp
+++ b/src/types/qwxdgshell.cpp
@@ -540,7 +540,7 @@ void QWXdgToplevel::sendClose()
     wlr_xdg_toplevel_send_close(handle());
 }
 
-bool QWXdgToplevel::setParsent(QWXdgToplevel *parent)
+bool QWXdgToplevel::setParent(QWXdgToplevel *parent)
 {
     return wlr_xdg_toplevel_set_parent(handle(), parent->handle());
 }

--- a/src/types/qwxdgshell.h
+++ b/src/types/qwxdgshell.h
@@ -137,7 +137,7 @@ public:
     uint32_t setWmCapabilities(uint32_t caps);
 
     void sendClose();
-    bool setParsent(QWXdgToplevel *parent);
+    bool setParent(QWXdgToplevel *parent);
 
 Q_SIGNALS:
     void requestMaximize(bool maximize);


### PR DESCRIPTION
fix: https://github.com/vioken/qwlroots/issues/146