### PR TITLE
Update nix flake input: nixpkgs and wlroots-git

### DIFF
--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -515,9 +515,13 @@ void TinywlServer::processCursorMotion(uint32_t time)
     wlr_surface *surface = nullptr;
     QPointF spos;
     auto view = viewAt(cursor->position(), &surface, &spos);
+#if WLR_VERSION_MINOR > 16
+    if (!view)
+        cursor->setXCursor(cursorManager, "left_ptr");
+#else
     if (!view)
         cursorManager->setCursor("left_ptr", cursor);
-
+#endif
     if (surface) {
         seat->pointerNotifyEnter(QWSurface::from(surface), spos.x(), spos.y());
         seat->pointerNotifyMotion(time, spos.x(), spos.y());

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687171271,
-        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687518131,
-        "narHash": "sha256-KirltRIc4SFfk8bTNudIqgKAALH5oqpW3PefmkfWK5M=",
+        "lastModified": 1688500189,
+        "narHash": "sha256-djYYiY4lzJOlXOnTHytH6BUugrxHDZjuGxTSrU4gt4M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8a93602bc54ece7a4e689d9aea1a574e2bbc24",
+        "rev": "78419edadf0fabbe5618643bd850b2f2198ed060",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -76,11 +76,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1687547394,
-        "narHash": "sha256-yYFlQsHD/TU0l6pS0t9tSHh7w+LFAUclJMpSyiA+Wnw=",
+        "lastModified": 1688545670,
+        "narHash": "sha256-b8NR+69ub5hEDpMEljNjAvd5ssqaQg5HKl4L4oiBlNQ=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "71b57b8d27e2817ebcaa6471e22251203c370554",
+        "rev": "77d5631e42fbcf3ceb51a1d607219228aeaabb00",
         "type": "gitlab"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     wlroots-unstable = {
       url = "gitlab:wlroots/wlroots?host=gitlab.freedesktop.org";

--- a/src/types/qwcursor.cpp
+++ b/src/types/qwcursor.cpp
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwcursor.h"
+#include "qwbuffer.h"
 #include "qwinputdevice.h"
 #include "qwcompositor.h"
 #include "util/qwsignalconnector.h"
-#include "types/qwoutputlayout.h"
+#include "qwoutputlayout.h"
 #include "qwoutput.h"
+#include "qwxcursormanager.h"
 
 #include <QImage>
 #include <QPointF>
@@ -254,12 +256,25 @@ void QWCursor::move(QWInputDevice *dev, const QPointF &deltaPos)
     wlr_cursor_move(handle(), dev ? dev->handle() : nullptr, deltaPos.x(), deltaPos.y());
 }
 
+#if WLR_VERSION_MINOR > 16
+void QWCursor::setBuffer(QWBuffer *buffer, const QPoint &hotspot, float scale)
+{
+    wlr_cursor_set_buffer(handle(), buffer->handle(),
+                         hotspot.x(), hotspot.y(), scale);
+}
+
+void QWCursor::setXCursor(QWXCursorManager *manager, const char *name)
+{
+    wlr_cursor_set_xcursor(handle(), manager->handle(), name);
+}
+#else
 void QWCursor::setImage(const QImage &image, const QPoint &hotspot)
 {
     wlr_cursor_set_image(handle(), reinterpret_cast<const uint8_t*>(image.constBits()),
                          image.bytesPerLine(), image.width(), image.height(),
                          hotspot.x(), hotspot.y(), image.devicePixelRatioF());
 }
+#endif
 
 void QWCursor::setSurface(QWSurface *surface, const QPoint &hotspot)
 {

--- a/src/types/qwcursor.h
+++ b/src/types/qwcursor.h
@@ -35,6 +35,8 @@ class QWOutputLayout;
 class QWCursorPrivate;
 class QWInputDevice;
 class QWOutput;
+class QWBuffer;
+class QWXCursorManager;
 
 class QW_EXPORT QWCursor : public QObject, public QWObject
 {
@@ -55,7 +57,12 @@ public:
     void warpClosest(QWInputDevice *dev, const QPointF &pos);
     void warpAbsolute(QWInputDevice *dev, const QPointF &pos);
     void move(QWInputDevice *dev, const QPointF &deltaPos);
+#if WLR_VERSION_MINOR > 16
+    void setBuffer(QWBuffer *buffer, const QPoint &hotspot, float scale);
+    void setXCursor(QWXCursorManager *manager, const char *name);
+#else
     void setImage(const QImage &image, const QPoint &hotspot);
+#endif
     void setSurface(QWSurface *surface, const QPoint &hotspot);
 
     void attachInputDevice(QWInputDevice *dev);

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -351,12 +351,14 @@ QWOutputCursor *QWOutputCursor::create(QWOutput *output)
     return from(handle);
 }
 
+#if WLR_VERSION_MINOR <= 16
 bool QWOutputCursor::setImage(const QImage &image, const QPoint &hotspot)
 {
     return wlr_output_cursor_set_image(handle(), reinterpret_cast<const uint8_t*>(image.constBits()),
                                        image.bitPlaneCount(), image.width(), image.height(),
                                        hotspot.x(), hotspot.y());
 }
+#endif
 
 bool QWOutputCursor::setBuffer(QWBuffer *buffer, const QPoint &hotspot)
 {

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -130,7 +130,9 @@ public:
     static QWOutputCursor *from(wlr_output_cursor *handle);
     static QWOutputCursor *create(QWOutput *output);
 
+#if WLR_VERSION_MINOR <= 16
     bool setImage(const QImage &image, const QPoint &hotspot);
+#endif
     bool setBuffer(QWBuffer *buffer, const QPoint &hotspot);
     bool move(const QPointF &pos);
 };

--- a/src/types/qwxcursormanager.cpp
+++ b/src/types/qwxcursormanager.cpp
@@ -43,9 +43,11 @@ wlr_xcursor *QWXCursorManager::getXCursor(const char *name, float scale) const
     return wlr_xcursor_manager_get_xcursor(handle(), name, scale);
 }
 
+#if WLR_VERSION_MINOR <= 16
 void QWXCursorManager::setCursor(const char *name, QWCursor *cursor)
 {
     wlr_xcursor_manager_set_cursor_image(handle(), name, cursor->handle());
 }
+#endif
 
 QW_END_NAMESPACE

--- a/src/types/qwxcursormanager.h
+++ b/src/types/qwxcursormanager.h
@@ -26,7 +26,9 @@ public:
 
     bool load(float scale);
     wlr_xcursor *getXCursor(const char *name, float scale) const;
+#if WLR_VERSION_MINOR <= 16
     void setCursor(const char *name, QWCursor *cursor);
+#endif
 };
 
 QW_END_NAMESPACE


### PR DESCRIPTION
* **cursor: replace wlr_cursor_set_image() with wlr_cursor_set_buffer()** (!4232):
  * `wlr_cursor_set_image()` has been replaced with `wlr_cursor_set_buffer()`
  * `wlr_xcursor_manager_set_cursor_image()` has been removed. Compositors should instead use `wlr_cursor_set_xcursor()`
* **output: drop wlr_output_cursor_set_image()** (!4250): `wlr_output_cursor_set_buffer()` can be used instead.cursor: replace wlr_cursor_set_image() with wlr_cursor_set_buffer() ([!4232 (merged)](https://github.com/wlroots/wlroots/-/merge_requests/4232)):


- wlr_cursor_set_image() has been replaced with wlr_cursor_set_buffer()


- wlr_xcursor_manager_set_cursor_image() has been removed. Compositors should instead use wlr_cursor_set_xcursor()




output: drop wlr_output_cursor_set_image() ([!4250 (merged)](https://github.com/wlroots/wlroots/-/merge_requests/4250)): wlr_output_cursor_set_buffer() can be used instead.