### PR TITLE
Make x11 dependency optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,10 +78,7 @@ set(SOURCES
     types/qwidleinhibitv1.cpp
     types/qwinputinhibitmanager.cpp
     types/qwkeyboardgroup.cpp
-    types/qwxwayland.cpp
-    types/qwxwaylandsurface.cpp
     types/qwpresentation.cpp
-    types/qwxwaylandserver.cpp
     types/qwviewporter.cpp
     types/qwxdgforeignregistry.cpp
     types/qwxdgoutputv1.cpp
@@ -173,10 +170,7 @@ set(HEADERS
     types/qwidleinhibitv1.h
     types/qwinputinhibitmanager.h
     types/qwkeyboardgroup.h
-    types/qwxwayland.h
-    types/qwxwaylandsurface.h
     types/qwpresentation.h
-    types/qwxwaylandserver.h
     types/qwxdgforeignregistry.h
     types/qwxdgforeignregistry_p.h
     types/qwxdgforeignv1.h
@@ -225,16 +219,35 @@ ws_generate(server wayland-protocols staging/content-type/content-type-v1.xml co
 list(APPEND SOURCES
     render/qwswapchain.cpp
     types/qwshm.cpp
-    types/qwxwaylandshellv1.cpp
     types/qwfractionalscalev1.cpp
     types/qwcontenttypev1.cpp
 )
 list(APPEND HEADERS
     render/qwswapchain.h
     types/qwshm.h
-    types/qwxwaylandshellv1.h
     types/qwfractionalscalev1.cpp
     types/qwcontenttypev1.h
+)
+    if(WLR_HAVE_XWAYLAND)
+        list(APPEND SOURCES
+            types/qwxwaylandshellv1.cpp
+        )
+        list(APPEND HEADERS
+            types/qwxwaylandshellv1.h
+        )
+    endif()
+endif()
+
+if (WLR_HAVE_XWAYLAND)
+list(APPEND SOURCES
+    types/qwxwayland.cpp
+    types/qwxwaylandsurface.cpp
+    types/qwxwaylandserver.cpp
+)
+list(APPEND HEADERS
+    types/qwxwayland.h
+    types/qwxwaylandsurface.h
+    types/qwxwaylandserver.h
 )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,19 +215,24 @@ set(PRIVATE_HEADERS
 )
 
 if ((${WLROOTS_VERSION_MAJOR} EQUAL 0) AND (${WLROOTS_VERSION_MINOR} GREATER 16))
-ws_generate(server wayland-protocols staging/content-type/content-type-v1.xml content-type-v1-protocol)
-list(APPEND SOURCES
-    render/qwswapchain.cpp
-    types/qwshm.cpp
-    types/qwfractionalscalev1.cpp
-    types/qwcontenttypev1.cpp
-)
-list(APPEND HEADERS
-    render/qwswapchain.h
-    types/qwshm.h
-    types/qwfractionalscalev1.cpp
-    types/qwcontenttypev1.h
-)
+    ws_generate(
+	server
+	wayland-protocols
+	staging/content-type/content-type-v1.xml
+	content-type-v1-protocol
+    )
+    list(APPEND SOURCES
+        render/qwswapchain.cpp
+        types/qwshm.cpp
+        types/qwfractionalscalev1.cpp
+        types/qwcontenttypev1.cpp
+    )
+    list(APPEND HEADERS
+        render/qwswapchain.h
+        types/qwshm.h
+        types/qwfractionalscalev1.cpp
+        types/qwcontenttypev1.h
+    )
     if(WLR_HAVE_XWAYLAND)
         list(APPEND SOURCES
             types/qwxwaylandshellv1.cpp

--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -16,7 +16,9 @@ extern "C" {
 #include <wlr/backend/drm.h>
 #undef static
 #include <wlr/backend/wayland.h>
+#ifdef WLR_HAVE_X11_BACKEND
 #include <wlr/backend/x11.h>
+#endif
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/headless.h>
 }
@@ -93,8 +95,10 @@ QWBackend *QWBackendPrivate::createBackend(wlr_backend *handle, bool isOwner, QO
 {
     if (wlr_backend_is_multi(handle))
         return new QWMultiBackend(handle, isOwner, parent);
+    #ifdef WLR_HAVE_X11_BACKEND
     if (wlr_backend_is_x11(handle))
         return new QWX11Backend(handle, isOwner, parent);
+    #endif
     if (wlr_backend_is_drm(handle))
         return new QWDrmBackend(handle, isOwner, parent);
     if (wlr_backend_is_headless(handle))
@@ -350,6 +354,8 @@ QWWaylandBackend::QWWaylandBackend(wlr_backend *handle, bool isOwner, QObject *p
 
 }
 
+#ifdef WLR_HAVE_X11_BACKEND
+
 QWX11Backend *QWX11Backend::get(wlr_backend *handle)
 {
     return qobject_cast<QWX11Backend*>(QWBackend::get(handle));
@@ -405,6 +411,8 @@ QWX11Backend::QWX11Backend(wlr_backend *handle, bool isOwner, QObject *parent)
 {
 
 }
+
+#endif
 
 QWLibinputBackend *QWLibinputBackend::get(wlr_backend *handle)
 {


### PR DESCRIPTION
In some pure-wayland distros, x11/xwayland will not be installed.