### PR TITLE
Add lost single for qwrenderer

### DIFF
--- a/src/render/qwrenderer.cpp
+++ b/src/render/qwrenderer.cpp
@@ -32,6 +32,9 @@ public:
         Q_ASSERT(!map.contains(handle));
         map.insert(handle, qq);
         sc.connect(&handle->events.destroy, this, &QWRendererPrivate::on_destroy);
+#if WLR_VERSION_MINOR > 16
+        sc.connect(&handle->events.lost, this, &QWRendererPrivate::on_lost);
+#endif
     }
     ~QWRendererPrivate() {
         if (!m_handle)
@@ -50,6 +53,9 @@ public:
     }
 
     void on_destroy(void *);
+#if WLR_VERSION_MINOR > 16
+    void on_lost(void *);
+#endif
 
     static QHash<void*, QWRenderer*> map;
     QW_DECLARE_PUBLIC(QWRenderer)
@@ -63,6 +69,13 @@ void QWRendererPrivate::on_destroy(void *)
     m_handle = nullptr;
     delete q_func();
 }
+
+#if WLR_VERSION_MINOR > 16
+void QWRendererPrivate::on_lost(void *)
+{
+    Q_EMIT q_func()->lost();
+}
+#endif
 
 QWRenderer *QWRenderer::get(wlr_renderer *handle)
 {

--- a/src/render/qwrenderer.h
+++ b/src/render/qwrenderer.h
@@ -74,6 +74,9 @@ public:
 
 Q_SIGNALS:
     void beforeDestroy(QWRenderer *self);
+#if WLR_VERSION_MINOR > 16
+    void lost();
+#endif
 
 private:
     QWRenderer(wlr_renderer *handle, bool isOwner);


### PR DESCRIPTION
Emitted when the GPU is lost, e.g. on GPU reset.
Compositors should destroy the renderer and re-create it.