### PR TITLE
fix: missing file from target sources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ set(SOURCES
     types/qwxdgforeignv1.cpp
     types/qwxdgforeignv2.cpp
     types/qwvirtualkeyboardv1.cpp
+    types/qwvirtualkeyboardmanagerv1.cpp
     types/qwvirtualpointerv1.cpp
     types/qwgammacontorlv1.cpp
     types/qwfullscreenshellv1.cpp


### PR DESCRIPTION
types/qwvirtualkeyboardmanagerv1.cpp is missing from target sources,
which will cause undefined reference when linked by others. Add this
file to SOURCES.

Log: fix missing file from target sources
