### PR TITLE
Make QWVirtualKeyboardV1 inherit form QWKeyboard

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,6 +212,7 @@ set(HEADERS
 
 set(PRIVATE_HEADERS
     types/qwinputdevice_p.h
+    types/qwkeyboard_p.h
 )
 
 if ((${WLROOTS_VERSION_MAJOR} EQUAL 0) AND (${WLROOTS_VERSION_MINOR} GREATER 16))

--- a/src/types/qwkeyboard.cpp
+++ b/src/types/qwkeyboard.cpp
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwkeyboard.h"
-#include "qwinputdevice_p.h"
-#include "util/qwsignalconnector.h"
+#include "qwkeyboard_p.h"
 
 extern "C" {
 #include <wlr/types/wlr_keyboard.h>
@@ -11,26 +10,19 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWKeyboardPrivate : public QWInputDevicePrivate
+QWKeyboardPrivate::QWKeyboardPrivate(wlr_keyboard *handle, bool isOwner, QWKeyboard *qq)
+    : QWInputDevicePrivate(&handle->base, isOwner, qq)
 {
-public:
-    QWKeyboardPrivate(wlr_keyboard *handle, bool isOwner, QWKeyboard *qq)
-        : QWInputDevicePrivate(&handle->base, isOwner, qq)
-    {
-        sc.connect(&handle->events.key, this, &QWKeyboardPrivate::on_key);
-        sc.connect(&handle->events.modifiers, this, &QWKeyboardPrivate::on_modifiers);
-        sc.connect(&handle->events.keymap, this, &QWKeyboardPrivate::on_keymap);
-        sc.connect(&handle->events.repeat_info, this, &QWKeyboardPrivate::on_repeat_info);
-    }
-    ~QWKeyboardPrivate() override = default;
+    sc.connect(&handle->events.key, this, &QWKeyboardPrivate::on_key);
+    sc.connect(&handle->events.modifiers, this, &QWKeyboardPrivate::on_modifiers);
+    sc.connect(&handle->events.keymap, this, &QWKeyboardPrivate::on_keymap);
+    sc.connect(&handle->events.repeat_info, this, &QWKeyboardPrivate::on_repeat_info);
+}
 
-    void on_key(void *);
-    void on_modifiers(void *);
-    void on_keymap(void *);
-    void on_repeat_info(void *);
+QWKeyboardPrivate::~QWKeyboardPrivate()
+{
 
-    QW_DECLARE_PUBLIC(QWKeyboard)
-};
+}
 
 void QWKeyboardPrivate::on_key(void *data)
 {
@@ -50,6 +42,12 @@ void QWKeyboardPrivate::on_keymap(void *)
 void QWKeyboardPrivate::on_repeat_info(void *)
 {
     Q_EMIT q_func()->repeatInfoChanged();
+}
+
+QWKeyboard::QWKeyboard(QWKeyboardPrivate &dd)
+    : QWInputDevice(dd)
+{
+
 }
 
 QWKeyboard::QWKeyboard(wlr_keyboard *handle, bool isOwner)

--- a/src/types/qwkeyboard.h
+++ b/src/types/qwkeyboard.h
@@ -48,8 +48,10 @@ Q_SIGNALS:
     void keymapChanged();
     void repeatInfoChanged();
 
-private:
+protected:
+    QWKeyboard(QWKeyboardPrivate &dd);
     ~QWKeyboard() override = default;
+private:
     QWKeyboard(wlr_keyboard *handle, bool isOwner);
 };
 

--- a/src/types/qwkeyboard_p.h
+++ b/src/types/qwkeyboard_p.h
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 rewine <luhongxu@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+// WARNING: This file is not part of the QWlroots API.
+
+#include "qwglobal.h"
+#include "qwinputdevice_p.h"
+#include "util/qwsignalconnector.h"
+
+QW_BEGIN_NAMESPACE
+
+class QWKeyboard;
+
+class QWKeyboardPrivate : public QWInputDevicePrivate
+{
+public:
+    QWKeyboardPrivate(wlr_keyboard *handle, bool isOwner, QWKeyboard *qq);
+    ~QWKeyboardPrivate() override;
+
+    void on_key(void *);
+    void on_modifiers(void *);
+    void on_keymap(void *);
+    void on_repeat_info(void *);
+
+    QW_DECLARE_PUBLIC(QWKeyboard)
+};
+
+QW_END_NAMESPACE

--- a/src/types/qwvirtualkeyboardv1.cpp
+++ b/src/types/qwvirtualkeyboardv1.cpp
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwvirtualkeyboardv1.h"
+#include "qwkeyboard_p.h"
+#include "qwinputdevice.h"
 #include "util/qwsignalconnector.h"
-
-#include <qwinputdevice.h>
 
 extern "C" {
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
@@ -12,14 +12,35 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-wlr_virtual_keyboard_v1 *QWVirtualKeyboardV1::handle() const
+class QWVirtualKeyboardV1Private : public QWKeyboardPrivate
 {
-    return reinterpret_cast<wlr_virtual_keyboard_v1*>(const_cast<QWVirtualKeyboardV1*>(this));
+public:
+    QWVirtualKeyboardV1Private(wlr_virtual_keyboard_v1 *handle, bool isOwner, QWVirtualKeyboardV1 *qq)
+        : QWKeyboardPrivate(&handle->keyboard, isOwner, qq)
+    {
+
+    }
+    ~QWVirtualKeyboardV1Private() override = default;
+
+    QW_DECLARE_PUBLIC(QWVirtualKeyboardV1)
+};
+
+QWVirtualKeyboardV1::QWVirtualKeyboardV1(wlr_virtual_keyboard_v1 *handle, bool isOwner)
+    : QWKeyboard(*new QWVirtualKeyboardV1Private(handle, isOwner, this))
+{
+
+}
+
+QWVirtualKeyboardV1 *QWVirtualKeyboardV1::get(wlr_virtual_keyboard_v1 *handle)
+{
+    return qobject_cast<QWVirtualKeyboardV1*>(QWKeyboard::get(&handle->keyboard));
 }
 
 QWVirtualKeyboardV1 *QWVirtualKeyboardV1::from(wlr_virtual_keyboard_v1 *handle)
 {
-    return reinterpret_cast<QWVirtualKeyboardV1*>(handle);
+    if (auto o = get(handle))
+        return o;
+    return new QWVirtualKeyboardV1(handle, false);
 }
 
 QWVirtualKeyboardV1 *QWVirtualKeyboardV1::fromInputDevice(QWInputDevice *inputDevice)

--- a/src/types/qwvirtualkeyboardv1.h
+++ b/src/types/qwvirtualkeyboardv1.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <qwglobal.h>
+#include <qwkeyboard.h>
 #include <QObject>
 
 struct wlr_virtual_keyboard_manager_v1;
@@ -13,16 +14,21 @@ QW_BEGIN_NAMESPACE
 
 class QWInputDevice;
 class QWVirtualKeyboardV1Private;
-class QW_EXPORT QWVirtualKeyboardV1
+class QW_EXPORT QWVirtualKeyboardV1: public QWKeyboard
 {
+    Q_OBJECT
 public:
-    QWVirtualKeyboardV1() = delete;
-    ~QWVirtualKeyboardV1() = delete;
+    inline wlr_virtual_keyboard_v1 *handle() const {
+        return QWObject::handle<wlr_virtual_keyboard_v1>();
+    }
 
-    wlr_virtual_keyboard_v1 *handle() const;
-
+    static QWVirtualKeyboardV1 *get(wlr_virtual_keyboard_v1 *handle);
     static QWVirtualKeyboardV1 *from(wlr_virtual_keyboard_v1 *handle);
     static QWVirtualKeyboardV1 *fromInputDevice(QWInputDevice *inputDevice);
+
+private:
+    ~QWVirtualKeyboardV1() override = default;
+    QWVirtualKeyboardV1(wlr_virtual_keyboard_v1 *handle, bool isOwner);
 };
 
 class QWDisplay;


### PR DESCRIPTION
wlr_virtual_keyboard_v1 is extended form wlr_keyboard, by object-oriented inheritance we can easily reuse QWKeyboard's signal binding