### PR TITLE
fix: crash getting keyboard

### DIFF
--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -188,7 +188,8 @@ void QWSeat::setKeyboard(QWKeyboard *keyboard)
 
 QWKeyboard *QWSeat::getKeyboard() const
 {
-    return QWKeyboard::from(wlr_seat_get_keyboard(handle()));
+    auto kb = wlr_seat_get_keyboard(handle());
+    return kb ? QWKeyboard::from(kb) : nullptr;
 }
 
 void QWSeat::setCapabilities(uint32_t capabilities)


### PR DESCRIPTION
When there is none keyboard event, there is no active seat keyboard. Getting keyboard from QWSeat might lead to crash cause getKeyboard() assumes that there is at least one active keyboard in seat.

Log: fix crash getting keyboard