### PR TITLE
hore: bump cmake compatibility version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.21)
 
 project(QWlroots
     VERSION 0.0.1


### PR DESCRIPTION
Version 3.21 is strongly recommended for more robust and easy syntax. Version less than 3.5 will soon be out of support.

Log: bump cmake compatibility version