### PR TITLE
Revert "Degrade Fedora Rawhide to 38 in obs ci"

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -15,10 +15,10 @@ test_build:
             architectures:
               - x86_64
 
-          - name: Fedora_38
+          - name: Fedora_Rawhide
             paths:
               - target_project: home:rewine:vioken
-                target_repository: Fedora_38
+                target_repository: Fedora_Rawhide
             architectures:
               - x86_64
 


### PR DESCRIPTION
This reverts commit a78eadbfe3a486584838977ecf7bf0c9f5d952bd.

obs-service-tar_scm support python 3.12 now: https://github.com/openSUSE/obs-service-tar_scm/issues/478