### PR TITLE
fix: compilation on wlroots 0.18.0

### DIFF
--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -157,7 +157,11 @@ TinywlServer::TinywlServer()
     subcompositor = QWSubcompositor::create(display);
     dataDeviceManager = QWDataDeviceManager::create(display);
 
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
     outputLayout = new QWOutputLayout(this);
+#else
+    outputLayout = new QWOutputLayout(display, this);
+#endif
     connect(backend, &QWBackend::newOutput, this, &TinywlServer::onNewOutput);
 
     scene = new QWScene(this);

--- a/src/interfaces/qwoutputinterface.cpp
+++ b/src/interfaces/qwoutputinterface.cpp
@@ -148,7 +148,9 @@ void QWOutputInterface::init(FuncMagicKey funMagicKey, QWBackend *backend, QWDis
     m_handleImpl = impl;
     m_handle = calloc(1, sizeof(_wlr_output));
     static_cast<_wlr_output *>(m_handle)->interface = this;
-#if WLR_VERSION_MINOR > 16
+#if WLR_VERSION_MINOR > 17
+    wlr_output_init(handle(), backend->handle(), impl, wl_display_get_event_loop(display->handle()), state);
+#elif WLR_VERSION_MINOR > 16
     wlr_output_init(handle(), backend->handle(), impl, display->handle(), state);
 #else
     wlr_output_init(handle(), backend->handle(), impl, display->handle());

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -3,6 +3,7 @@
 
 #include "qwoutput.h"
 #include "qwbuffer.h"
+#include "qwdisplay.h"
 #include "util/qwsignalconnector.h"
 #include "render/qwallocator.h"
 #include "render/qwrenderer.h"
@@ -163,10 +164,17 @@ void QWOutput::enable(bool enable)
     wlr_output_enable(handle(), enable);
 }
 
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
 void QWOutput::createGlobal()
 {
     wlr_output_create_global(handle());
 }
+#else
+void QWOutput::createGlobal(QWDisplay *display)
+{
+    wlr_output_create_global(handle(), display->handle());
+}
+#endif
 
 void QWOutput::destroyGlobal()
 {

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -61,7 +61,11 @@ public:
     }
 
     void enable(bool enable);
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
     void createGlobal();
+#else
+    void createGlobal(QWDisplay *display);
+#endif
     void destroyGlobal();
     bool initRender(QWAllocator *allocator, QWRenderer *renderer);
     wlr_output_mode *preferredMode() const;

--- a/src/types/qwoutputlayout.cpp
+++ b/src/types/qwoutputlayout.cpp
@@ -4,6 +4,7 @@
 #include "qwoutputlayout.h"
 #include "util/qwsignalconnector.h"
 #include "qwoutput.h"
+#include "qwdisplay.h"
 
 #include <QPointF>
 #include <QRect>
@@ -83,11 +84,19 @@ QWOutputLayout::QWOutputLayout(wlr_output_layout *handle, bool isOwner, QObject 
 
 }
 
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
 QWOutputLayout::QWOutputLayout(QObject *parent)
     : QWOutputLayout(wlr_output_layout_create(), true, parent)
 {
 
 }
+#else
+QWOutputLayout::QWOutputLayout(QWDisplay *display, QObject *parent)
+    : QWOutputLayout(wlr_output_layout_create(display->handle()), true, parent)
+{
+
+}
+#endif
 
 QWOutputLayout *QWOutputLayout::get(wlr_output_layout *handle)
 {

--- a/src/types/qwoutputlayout.h
+++ b/src/types/qwoutputlayout.h
@@ -13,6 +13,7 @@ typedef uint32_t wlr_direction_t;
 
 QW_BEGIN_NAMESPACE
 
+class QWDisplay;
 class QWOutput;
 class QWRenderer;
 class QWOutputLayoutPrivate;
@@ -21,7 +22,11 @@ class QW_EXPORT QWOutputLayout : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWOutputLayout)
 public:
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
     explicit QWOutputLayout(QObject *parent = nullptr);
+#else
+    explicit QWOutputLayout(QWDisplay *display, QObject *parent = nullptr);
+#endif
     ~QWOutputLayout() = default;
 
     inline wlr_output_layout *handle() const {


### PR DESCRIPTION
wlr_output_layout_create has changed its signature, now we need the display to create output layout. Just make QWOutputLayout's constructor private and add create() to create from display. wlr_output_init now needs the event loop.

Log: fix compilation on wlroots 0.18.0