### PR TITLE
Bump WLROOTS to 0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ result
 
 # clangd
 .cache/
+
+# vscode
+.vscode/

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper-compat (= 13),
                qt6-base-dev-tools,
                wayland-protocols,
 	       wlr-protocols,
-               libwlroots-dev (>=0.16.0),
+               libwlroots-dev (>=0.17.0),
                libpixman-1-dev,
                libxcb-ewmh-dev,
 	       libdrm-dev

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,20 @@
-{ pkgs ? import <inxpkgs> { }, nix-filter }:
+{ pkgs ? import <inxpkgs> { }, wlroots_master_src ? null , nix-filter }:
+let
+  mkDate = longDate: (pkgs.lib.concatStringsSep "-" [
+    (builtins.substring 0 4 longDate)
+    (builtins.substring 4 2 longDate)
+    (builtins.substring 6 2 longDate)
+  ]);
 
+  wlroots_master = pkgs.wlroots_0_17.overrideAttrs (
+    old: {
+      version = "0.18.0";
+      src = wlroots_master_src;
+      patches = [];
+    }
+  );
+
+in
 rec {
   qwlroots-qt6 = pkgs.qt6.callPackage ./nix {
     inherit nix-filter;
@@ -13,6 +28,10 @@ rec {
 
   qwlroots-qt6-wlroots-16 = qwlroots-qt6.override {
     wlroots = pkgs.wlroots_0_16;
+  };
+
+  qwlroots-qt6-wlroots-master = qwlroots-qt6.override {
+    wlroots = wlroots_master;
   };
 
   qwlroots-qt6-dbg = qwlroots-qt6.override {

--- a/default.nix
+++ b/default.nix
@@ -26,10 +26,6 @@ rec {
     wlroots = pkgs.wlroots_0_17;
   };
 
-  qwlroots-qt6-wlroots-16 = qwlroots-qt6.override {
-    wlroots = pkgs.wlroots_0_16;
-  };
-
   qwlroots-qt6-wlroots-master = qwlroots-qt6.override {
     wlroots = wlroots_master;
   };

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -212,15 +212,16 @@ void TinywlServer::onNewOutput(QWOutput *output)
 {
     Q_ASSERT(output);
     outputs.append(output);
-
     output->initRender(allocator, renderer);
+
+    wlr_output_state state;
+    wlr_output_state_init(&state);
     if (!wl_list_empty(&output->handle()->modes)) {
         auto *mode = output->preferredMode();
-        output->setMode(mode);
+        wlr_output_state_set_mode(&state, mode);
     }
-
-    output->enable(true);
-    if (!output->commit())
+    wlr_output_state_set_enabled(&state, true);
+    if (!output->commitState(&state))
         return;
 
     connect(output, &QWOutput::frame, this, &TinywlServer::onOutputFrame);

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -329,7 +329,11 @@ void TinywlServer::onCursorButton(wlr_pointer_button_event *event)
     QPointF spos;
     wlr_surface *surface = nullptr;
     auto view = viewAt(cursor->position(), &surface, &spos);
+#if WLR_VERSION_MINOR > 17
+    if (event->state == WL_POINTER_BUTTON_STATE_RELEASED) {
+#else
     if (event->state == WLR_BUTTON_RELEASED) {
+#endif
         cursorState = CursorState::Normal;
     } else {
         focusView(view, surface);

--- a/examples/tinywl/main.cpp
+++ b/examples/tinywl/main.cpp
@@ -472,11 +472,7 @@ void TinywlServer::onOutputFrame()
     auto output = qobject_cast<QWOutput*>(sender());
     Q_ASSERT(output);
     auto sceneOutput = QWSceneOutput::from(scene, output);
-#if WLR_VERSION_MINOR > 16
     sceneOutput->commit(nullptr);
-#else
-    sceneOutput->commit();
-#endif
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     sceneOutput->sendFrameDone(&now);
@@ -495,11 +491,7 @@ TinywlServer::View *TinywlServer::viewAt(const QPointF &pos, wlr_surface **surfa
         return nullptr;
     }
     auto *sceneBuffer = QWSceneBuffer::from(node);
-#if WLR_VERSION_MINOR > 16
     auto *sceneSurface = wlr_scene_surface_try_from_buffer(sceneBuffer->handle());
-#else
-    auto *sceneSurface = wlr_scene_surface_from_buffer(sceneBuffer->handle());
-#endif
     if (!sceneSurface)
         return nullptr;
 
@@ -565,13 +557,8 @@ void TinywlServer::processCursorMotion(uint32_t time)
     wlr_surface *surface = nullptr;
     QPointF spos;
     auto view = viewAt(cursor->position(), &surface, &spos);
-#if WLR_VERSION_MINOR > 16
     if (!view)
         cursor->setXCursor(cursorManager, "left_ptr");
-#else
-    if (!view)
-        cursorManager->setCursor("left_ptr", cursor);
-#endif
     if (surface) {
         seat->pointerNotifyEnter(QWSurface::from(surface), spos.x(), spos.y());
         seat->pointerNotifyMotion(time, spos.x(), spos.y());

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1701697642,
-        "narHash": "sha256-L217WytWZHSY8GW9Gx1A64OnNctbuDbfslaTEofXXRw=",
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "c843418ecfd0344ecb85844b082ff5675e02c443",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -53,7 +53,8 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "wlroots-master": "wlroots-master"
       }
     },
     "systems": {
@@ -69,6 +70,25 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "wlroots-master": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.freedesktop.org",
+        "lastModified": 1712005248,
+        "narHash": "sha256-0YdQL4pDFHAk++ElDdpyigtEaqVsPfhtydY+qUcmb0U=",
+        "owner": "wlroots",
+        "repo": "wlroots",
+        "rev": "f0ce906b73419000c1d61c2b88e6d5f4f36d2041",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.freedesktop.org",
+        "owner": "wlroots",
+        "ref": "master",
+        "repo": "wlroots",
+        "type": "gitlab"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,13 @@
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    wlroots-master = {
+      url = "gitlab:wlroots/wlroots?host=gitlab.freedesktop.org&ref=master";
+      flake = false;
+    };
   };
 
-  outputs = { self, flake-utils, nix-filter, nixpkgs }@input:
+  outputs = { self, flake-utils, nix-filter, nixpkgs, wlroots-master }@input:
     flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "riscv64-linux" ]
       (system:
         let
@@ -16,6 +20,7 @@
         rec {
           packages = import ./default.nix {
             inherit pkgs nix-filter;
+            wlroots_master_src = wlroots-master;
           };
 
           devShells.default = pkgs.mkShell { 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Qt${QT_VERSION_MAJOR}
     REQUIRED
 )
 
-set(WLROOTS_MINIMUM_REQUIRED 0.16.0)
+set(WLROOTS_MINIMUM_REQUIRED 0.17.0)
 find_package(PkgConfig REQUIRED)
 pkg_search_module(WLROOTS REQUIRED IMPORTED_TARGET wlroots>=${WLROOTS_MINIMUM_REQUIRED})
 pkg_search_module(WAYLAND_SERVER REQUIRED IMPORTED_TARGET wayland-server)
@@ -216,53 +216,44 @@ set(PRIVATE_HEADERS
     types/qwkeyboard_p.h
 )
 
-if ((${WLROOTS_VERSION_MAJOR} EQUAL 0) AND (${WLROOTS_VERSION_MINOR} GREATER 16))
-    ws_generate(
-        server
-        wayland-protocols
-        staging/content-type/content-type-v1.xml
-        content-type-v1-protocol
-    )
-    ws_generate(
-        server
-        wayland-protocols
-        staging/cursor-shape/cursor-shape-v1.xml
-        cursor-shape-v1-protocol
-    )
+ws_generate(
+    server
+    wayland-protocols
+    staging/content-type/content-type-v1.xml
+    content-type-v1-protocol
+)
+ws_generate(
+    server
+    wayland-protocols
+    staging/cursor-shape/cursor-shape-v1.xml
+    cursor-shape-v1-protocol
+)
 
+list(APPEND SOURCES
+    render/qwswapchain.cpp
+    types/qwshm.cpp
+    types/qwfractionalscalev1.cpp
+    types/qwcontenttypev1.cpp
+    types/qwcursorshapev1.cpp
+)
+list(APPEND HEADERS
+    render/qwswapchain.h
+    types/qwshm.h
+    types/qwfractionalscalev1.cpp
+    types/qwcontenttypev1.h
+    types/qwcursorshapev1.h
+)
+if(WLR_HAVE_XWAYLAND)
     list(APPEND SOURCES
-        render/qwswapchain.cpp
-        types/qwshm.cpp
-        types/qwfractionalscalev1.cpp
-        types/qwcontenttypev1.cpp
-        types/qwcursorshapev1.cpp
+        types/qwxwaylandshellv1.cpp
     )
     list(APPEND HEADERS
-        render/qwswapchain.h
-        types/qwshm.h
-        types/qwfractionalscalev1.cpp
-        types/qwcontenttypev1.h
-        types/qwcursorshapev1.h
+        types/qwxwaylandshellv1.h
     )
-    if(WLR_HAVE_XWAYLAND)
-        list(APPEND SOURCES
-            types/qwxwaylandshellv1.cpp
-        )
-        list(APPEND HEADERS
-            types/qwxwaylandshellv1.h
-        )
-    endif()
-    if (${WLROOTS_VERSION_MINOR} GREATER_EQUAL 18)
-        list(REMOVE_ITEM HEADERS types/qwinputinhibitmanager.h)
-        list(REMOVE_ITEM SOURCES types/qwinputinhibitmanager.cpp)
-    endif()
-else()
-    list(APPEND SOURCES
-        types/qwidle.cpp
-    )
-    list(APPEND HEADERS
-        types/qwidle.h
-    )
+endif()
+if (${WLROOTS_VERSION_MINOR} GREATER_EQUAL 18)
+    list(REMOVE_ITEM HEADERS types/qwinputinhibitmanager.h)
+    list(REMOVE_ITEM SOURCES types/qwinputinhibitmanager.cpp)
 endif()
 
 if (WLR_HAVE_XWAYLAND)

--- a/src/interfaces/qwbackendinterface.cpp
+++ b/src/interfaces/qwbackendinterface.cpp
@@ -32,12 +32,6 @@ static void destroy(wlr_backend *handle) {
     delete interface(handle);
 }
 
-#if WLR_VERSION_MINOR <= 16
-static clockid_t get_presentation_clock(wlr_backend *handle) {
-    return interface(handle)->getPresentationClock();
-}
-#endif
-
 static int get_drm_fd(wlr_backend *handle) {
     return interface(handle)->getDrmFd();
 }
@@ -53,13 +47,6 @@ QWBackendInterface::~QWBackendInterface()
     free(handle());
     delete impl();
 }
-
-#if WLR_VERSION_MINOR <= 16
-clockid_t QWBackendInterface::getPresentationClock() const
-{
-    return CLOCK_MONOTONIC;
-}
-#endif
 
 int QWBackendInterface::getDrmFd() const
 {
@@ -81,9 +68,6 @@ void QWBackendInterface::init(FuncMagicKey funMagicKey)
     auto impl = new wlr_backend_impl {
         .start = impl::start,
         .destroy = impl::destroy,
-#if WLR_VERSION_MINOR <= 16
-        QW_INIT_INTERFACE_FUNC(funMagicKey, get_presentation_clock, &QWBackendInterface::getPresentationClock),
-#endif
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_drm_fd, &QWBackendInterface::getDrmFd),
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_buffer_caps, &QWBackendInterface::getBufferCaps),
     };

--- a/src/interfaces/qwbackendinterface.h
+++ b/src/interfaces/qwbackendinterface.h
@@ -17,9 +17,6 @@ public:
     virtual ~QWBackendInterface();
     virtual bool start() = 0;
 
-#if WLR_VERSION_MINOR <= 16
-    virtual clockid_t getPresentationClock() const;
-#endif
     virtual int getDrmFd() const;
     virtual int getBufferCaps() const;
 

--- a/src/interfaces/qwoutputinterface.cpp
+++ b/src/interfaces/qwoutputinterface.cpp
@@ -127,11 +127,7 @@ QWOutputInterface *QWOutputInterface::get(wlr_output *handle)
     return interface(handle);
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWOutputInterface::init(FuncMagicKey funMagicKey, QWBackend *backend, QWDisplay *display, wlr_output_state *state)
-#else
-void QWOutputInterface::init(FuncMagicKey funMagicKey, QWBackend *backend, QWDisplay *display)
-#endif
 {
     auto impl = new wlr_output_impl {
         QW_INIT_INTERFACE_FUNC(funMagicKey, set_cursor, &QWOutputInterface::setCursor),
@@ -150,10 +146,8 @@ void QWOutputInterface::init(FuncMagicKey funMagicKey, QWBackend *backend, QWDis
     static_cast<_wlr_output *>(m_handle)->interface = this;
 #if WLR_VERSION_MINOR > 17
     wlr_output_init(handle(), backend->handle(), impl, wl_display_get_event_loop(display->handle()), state);
-#elif WLR_VERSION_MINOR > 16
-    wlr_output_init(handle(), backend->handle(), impl, display->handle(), state);
 #else
-    wlr_output_init(handle(), backend->handle(), impl, display->handle());
+    wlr_output_init(handle(), backend->handle(), impl, display->handle(), state);
 #endif
 }
 

--- a/src/interfaces/qwoutputinterface.h
+++ b/src/interfaces/qwoutputinterface.h
@@ -41,7 +41,6 @@ public:
     static QWOutputInterface *get(wlr_output *handle);
 
 protected:
-#if WLR_VERSION_MINOR > 16
     template<class T>
     inline void init(QWBackend *backend, QWDisplay *display, wlr_output_state *state) {
         init(getFuncMagicKey<T>(&T::setCursor, &T::moveCursor, &T::test,
@@ -51,17 +50,6 @@ protected:
     }
 
     virtual void init(FuncMagicKey funMagicKey, QWBackend *backend, QWDisplay *display, wlr_output_state *state);
-#else
-    template<class T>
-    inline void init(QWBackend *backend, QWDisplay *display) {
-        init(getFuncMagicKey<T>(&T::setCursor, &T::moveCursor, &T::test,
-                                &T::getGammaSize, &T::getCursorFormats,
-                                &T::getPrimaryFormats, &T::getCursorSize),
-             backend, display);
-    }
-
-    virtual void init(FuncMagicKey funMagicKey, QWBackend *backend, QWDisplay *display);
-#endif
 };
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwrendererinterface.cpp
+++ b/src/interfaces/qwrendererinterface.cpp
@@ -346,20 +346,22 @@ wlr_render_timer *QWRendererInterface::renderTimerCreate() {
 void QWRendererInterface::init(FuncMagicKey funMagicKey)
 {
     auto impl = new wlr_renderer_impl {
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
         QW_INIT_INTERFACE_FUNC(funMagicKey, bind_buffer, &QWRendererInterface::bindBuffer),
         QW_INIT_INTERFACE_FUNC(funMagicKey, begin, &QWRendererInterface::begin),
         QW_INIT_INTERFACE_FUNC(funMagicKey, end, &QWRendererInterface::end),
-        #if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
         QW_INIT_INTERFACE_FUNC(funMagicKey, clear, &QWRendererInterface::clear),
         QW_INIT_INTERFACE_FUNC(funMagicKey, scissor, &QWRendererInterface::scissor),
         QW_INIT_INTERFACE_FUNC(funMagicKey, render_subtexture_with_matrix, &QWRendererInterface::renderSubtextureWithMatrix),
         QW_INIT_INTERFACE_FUNC(funMagicKey, render_quad_with_matrix, &QWRendererInterface::renderQuadWithMatrix),
-        #endif
+#endif
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_shm_texture_formats, &QWRendererInterface::getShmTextureFormats),
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_dmabuf_texture_formats, &QWRendererInterface::getDmabufTextureFormats),
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_render_formats, &QWRendererInterface::getRenderFormats),
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
         QW_INIT_INTERFACE_FUNC(funMagicKey, preferred_read_format, &QWRendererInterface::preferredReadFormat),
         QW_INIT_INTERFACE_FUNC(funMagicKey, read_pixels, &QWRendererInterface::readPixels),
+#endif
         .destroy = impl::destroy,
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_drm_fd, &QWRendererInterface::getDrmFd),
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_render_buffer_caps, &QWRendererInterface::getRenderBufferCaps),

--- a/src/interfaces/qwrendererinterface.cpp
+++ b/src/interfaces/qwrendererinterface.cpp
@@ -146,11 +146,7 @@ static bool bind_buffer(wlr_renderer *handle, wlr_buffer *buffer)
     return interface(handle)->bindBuffer(QWBuffer::from(buffer));
 }
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR <= 16
-static void begin(wlr_renderer *handle, uint32_t width, uint32_t height)
-#else
 static bool begin(wlr_renderer *handle, uint32_t width, uint32_t height)
-#endif
 {
     return interface(handle)->begin({uint32ToPixelSize(width), uint32ToPixelSize(height)});
 }
@@ -267,7 +263,6 @@ static wlr_texture *texture_from_buffer(wlr_renderer *handle, wlr_buffer *buffer
     return texture ? texture->handle() : nullptr;
 }
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
 static wlr_render_pass *begin_buffer_pass(wlr_renderer *handle, wlr_buffer *buffer, const wlr_buffer_pass_options *options) {
     return interface(handle)->beginBufferPass(QWBuffer::from(buffer), options);
 }
@@ -275,7 +270,6 @@ static wlr_render_pass *begin_buffer_pass(wlr_renderer *handle, wlr_buffer *buff
 static wlr_render_timer *render_timer_create(wlr_renderer *handle) {
     return interface(handle)->renderTimerCreate();
 }
-#endif
 } // namespace impl
 
 QWRendererInterface::~QWRendererInterface()
@@ -333,7 +327,6 @@ QWTexture *QWRendererInterface::textureFromBuffer(QWBuffer *) const
     return nullptr;
 }
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
 wlr_render_pass *QWRendererInterface::beginBufferPass(QWBuffer *, const wlr_buffer_pass_options *) {
     return nullptr;
 }
@@ -341,7 +334,6 @@ wlr_render_pass *QWRendererInterface::beginBufferPass(QWBuffer *, const wlr_buff
 wlr_render_timer *QWRendererInterface::renderTimerCreate() {
     return nullptr;
 }
-#endif
 
 void QWRendererInterface::init(FuncMagicKey funMagicKey)
 {
@@ -366,10 +358,8 @@ void QWRendererInterface::init(FuncMagicKey funMagicKey)
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_drm_fd, &QWRendererInterface::getDrmFd),
         QW_INIT_INTERFACE_FUNC(funMagicKey, get_render_buffer_caps, &QWRendererInterface::getRenderBufferCaps),
         QW_INIT_INTERFACE_FUNC(funMagicKey, texture_from_buffer, &QWRendererInterface::textureFromBuffer),
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
         QW_INIT_INTERFACE_FUNC(funMagicKey, begin_buffer_pass, &QWRendererInterface::beginBufferPass),
         QW_INIT_INTERFACE_FUNC(funMagicKey, render_timer_create, &QWRendererInterface::renderTimerCreate),
-#endif
     };
     m_handleImpl = impl;
     m_handle = calloc(1, sizeof(_wlr_renderer));

--- a/src/interfaces/qwrendererinterface.h
+++ b/src/interfaces/qwrendererinterface.h
@@ -27,11 +27,7 @@ public:
     virtual ~QWRendererInterface();
 
     virtual bool bindBuffer(QWBuffer *buffer);
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR <= 16
-    virtual void begin(const QSize &size) = 0;
-#else
     virtual bool begin(const QSize &size) = 0;
-#endif
     virtual void end() = 0;
 
 #if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
@@ -54,10 +50,8 @@ public:
 
     virtual QWTexture *textureFromBuffer(QWBuffer *buffer) const;
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
     wlr_render_pass *beginBufferPass(QWBuffer *buffer, const wlr_buffer_pass_options *options);
     wlr_render_timer *renderTimerCreate();
-#endif
 
     virtual const QVector<uint32_t>* getShmTextureFormats() const;
 
@@ -87,12 +81,9 @@ protected:
                                 &T::readPixels,
                                 &T::getDrmFd,
                                 &T::getRenderBufferCaps,
-                                &T::textureFromBuffer
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
-                                ,
+                                &T::textureFromBuffer,
                                 &T::beginBufferPass,
                                 &T::renderTimerCreate
-#endif
         ));
     }
 

--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -120,7 +120,9 @@ QWBackend *QWBackend::from(wlr_backend *handle)
 
 QWBackend *QWBackend::autoCreate(QWDisplay *display, QObject *parent)
 {
-#if WLR_VERSION_MINOR > 16
+#if WLR_VERSION_MINOR >= 18
+    auto handle = wlr_backend_autocreate(display->eventLoop(), nullptr);
+#elif WLR_VERSION_MINOR > 16
     auto handle = wlr_backend_autocreate(display->handle(), nullptr);
 #else
     auto handle = wlr_backend_autocreate(display->handle());
@@ -188,6 +190,15 @@ QWMultiBackend *QWMultiBackend::from(wlr_backend *handle)
     return new QWMultiBackend(handle, false);
 }
 
+#if WLR_VERSION_MINOR > 17
+QWMultiBackend *QWMultiBackend::create(wl_event_loop *eventloop, QObject *parent)
+{
+    auto handle = wlr_multi_backend_create(eventloop);
+    if (!handle)
+        return nullptr;
+    return new QWMultiBackend(handle, true, parent);
+}
+#else
 QWMultiBackend *QWMultiBackend::create(QWDisplay *display, QObject *parent)
 {
     auto handle = wlr_multi_backend_create(display->handle());
@@ -195,6 +206,7 @@ QWMultiBackend *QWMultiBackend::create(QWDisplay *display, QObject *parent)
         return nullptr;
     return new QWMultiBackend(handle, true, parent);
 }
+#endif
 
 bool QWMultiBackend::add(QWBackend *backend)
 {
@@ -241,6 +253,16 @@ QWDrmBackend *QWDrmBackend::from(wlr_backend *handle)
     return new QWDrmBackend(handle, false);
 }
 
+#if WLR_VERSION_MINOR > 17
+// TODO: use QWSession and QWDevice
+QWDrmBackend *QWDrmBackend::create(wlr_session *session, wlr_device *dev, QWBackend *parent)
+{
+    auto handle = wlr_drm_backend_create(session, dev, parent->handle());
+    if (!handle)
+        return nullptr;
+    return new QWDrmBackend(handle, true, parent);
+}
+#else
 QWDrmBackend *QWDrmBackend::create(QWDisplay *display, wlr_session *session, wlr_device *dev, QWBackend *parent)
 {
     auto handle = wlr_drm_backend_create(display->handle(), session, dev, parent->handle());
@@ -248,6 +270,7 @@ QWDrmBackend *QWDrmBackend::create(QWDisplay *display, wlr_session *session, wlr
         return nullptr;
     return new QWDrmBackend(handle, true, parent);
 }
+#endif
 
 bool QWDrmBackend::isDrmOutput(QWOutput *output)
 {
@@ -309,7 +332,15 @@ QWWaylandBackend *QWWaylandBackend::from(wlr_backend *handle)
     return new QWWaylandBackend(handle, false);
 }
 
-#if WLR_VERSION_MINOR > 16
+#if WLR_VERSION_MINOR > 17
+QWWaylandBackend *QWWaylandBackend::create(wl_event_loop *eventloop, wl_display *remote_display, QObject *parent)
+{
+    auto handle = wlr_wl_backend_create(eventloop, remote_display);
+    if (!handle)
+        return nullptr;
+    return new QWWaylandBackend(handle, true, parent);
+}
+#elif WLR_VERSION_MINOR > 16
 QWWaylandBackend *QWWaylandBackend::create(QWDisplay *display, wl_display *remote_display, QObject *parent)
 {
     auto handle = wlr_wl_backend_create(display->handle(), remote_display);
@@ -387,6 +418,15 @@ QWX11Backend *QWX11Backend::from(wlr_backend *handle)
     return new QWX11Backend(handle, false);
 }
 
+#if WLR_VERSION_MINOR > 17
+QWX11Backend *QWX11Backend::create(wl_event_loop *eventloop, const char *x11Display, QObject *parent)
+{
+    auto handle = wlr_x11_backend_create(eventloop, x11Display);
+    if (!handle)
+        return nullptr;
+    return new QWX11Backend(handle, true, parent);
+}
+#else
 QWX11Backend *QWX11Backend::create(QWDisplay *display, const char *x11Display, QObject *parent)
 {
     auto handle = wlr_x11_backend_create(display->handle(), x11Display);
@@ -394,6 +434,7 @@ QWX11Backend *QWX11Backend::create(QWDisplay *display, const char *x11Display, Q
         return nullptr;
     return new QWX11Backend(handle, true, parent);
 }
+#endif
 
 QWOutput *QWX11Backend::createOutput()
 {
@@ -445,6 +486,15 @@ QWLibinputBackend *QWLibinputBackend::from(wlr_backend *handle)
     return new QWLibinputBackend(handle, false);
 }
 
+#if WLR_VERSION_MINOR > 17
+QWLibinputBackend *QWLibinputBackend::create(wlr_session *session, QObject *parent)
+{
+    auto handle = wlr_libinput_backend_create(session);
+    if (!handle)
+        return nullptr;
+    return new QWLibinputBackend(handle, true, parent);
+}
+#else
 QWLibinputBackend *QWLibinputBackend::create(QWDisplay *display, wlr_session *session, QObject *parent)
 {
     auto handle = wlr_libinput_backend_create(display->handle(), session);
@@ -452,6 +502,7 @@ QWLibinputBackend *QWLibinputBackend::create(QWDisplay *display, wlr_session *se
         return nullptr;
     return new QWLibinputBackend(handle, true, parent);
 }
+#endif
 
 bool QWLibinputBackend::isLibinputDevice(QWInputDevice *device)
 {
@@ -488,6 +539,15 @@ QWHeadlessBackend *QWHeadlessBackend::from(wlr_backend *handle)
     return new QWHeadlessBackend(handle, false);
 }
 
+#if WLR_VERSION_MINOR > 17
+QWHeadlessBackend *QWHeadlessBackend::create(wl_event_loop *eventloop, QObject *parent)
+{
+    auto handle = wlr_headless_backend_create(eventloop);
+    if (!handle)
+        return nullptr;
+    return new QWHeadlessBackend(handle, true, parent);
+}
+#else
 QWHeadlessBackend *QWHeadlessBackend::create(QWDisplay *display, QObject *parent)
 {
     auto handle = wlr_headless_backend_create(display->handle());
@@ -495,6 +555,7 @@ QWHeadlessBackend *QWHeadlessBackend::create(QWDisplay *display, QObject *parent
         return nullptr;
     return new QWHeadlessBackend(handle, true, parent);
 }
+#endif
 
 QWOutput *QWHeadlessBackend::addOutput(unsigned int width, unsigned int height)
 {

--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -122,10 +122,8 @@ QWBackend *QWBackend::autoCreate(QWDisplay *display, QObject *parent)
 {
 #if WLR_VERSION_MINOR >= 18
     auto handle = wlr_backend_autocreate(display->eventLoop(), nullptr);
-#elif WLR_VERSION_MINOR > 16
-    auto handle = wlr_backend_autocreate(display->handle(), nullptr);
 #else
-    auto handle = wlr_backend_autocreate(display->handle());
+    auto handle = wlr_backend_autocreate(display->handle(), nullptr);
 #endif
     if (!handle)
         return nullptr;
@@ -150,14 +148,6 @@ QWBackend::~QWBackend()
 {
 
 }
-
-#if WLR_VERSION_MINOR <= 16
-clockid_t QWBackend::presentationClock() const
-{
-    Q_D(const QWBackend);
-    return wlr_backend_get_presentation_clock(handle());
-}
-#endif
 
 int QWBackend::drmFd() const
 {
@@ -340,18 +330,10 @@ QWWaylandBackend *QWWaylandBackend::create(wl_event_loop *eventloop, wl_display 
         return nullptr;
     return new QWWaylandBackend(handle, true, parent);
 }
-#elif WLR_VERSION_MINOR > 16
+#else
 QWWaylandBackend *QWWaylandBackend::create(QWDisplay *display, wl_display *remote_display, QObject *parent)
 {
     auto handle = wlr_wl_backend_create(display->handle(), remote_display);
-    if (!handle)
-        return nullptr;
-    return new QWWaylandBackend(handle, true, parent);
-}
-#else
-QWWaylandBackend *QWWaylandBackend::create(QWDisplay *display, const char *remote, QObject *parent)
-{
-    auto handle = wlr_wl_backend_create(display->handle(), remote);
     if (!handle)
         return nullptr;
     return new QWWaylandBackend(handle, true, parent);

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -51,9 +51,6 @@ public:
         return new QWBackend(i->handle(), true, nullptr);
     }
 
-#if WLR_VERSION_MINOR <= 16
-    clockid_t presentationClock() const;
-#endif
     int drmFd() const;
 
 public Q_SLOTS:
@@ -130,10 +127,8 @@ public:
     static QWWaylandBackend *from(wlr_backend *handle);
 #if WLR_VERSION_MINOR > 17
     static QWWaylandBackend *create(wl_event_loop *eventloop, wl_display *remote_display, QObject *parent = nullptr);
-#elif WLR_VERSION_MINOR > 16
-    static QWWaylandBackend *create(QWDisplay *display, wl_display *remote_display, QObject *parent = nullptr);
 #else
-    static QWWaylandBackend *create(QWDisplay *display, const char *remote, QObject *parent = nullptr);
+    static QWWaylandBackend *create(QWDisplay *display, wl_display *remote_display, QObject *parent = nullptr);
 #endif
     wl_display *getRemoteDisplay() const;
     QWOutput *createOutput();

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -16,6 +16,7 @@ struct wlr_device;
 struct wlr_output_mode;
 struct wlr_drm_lease;
 struct wl_display;
+struct wl_event_loop;
 struct wl_seat;
 struct wl_surface;
 struct libinput_device;
@@ -76,7 +77,11 @@ class QW_EXPORT QWMultiBackend : public QWBackend
 public:
     static QWMultiBackend *get(wlr_backend *handle);
     static QWMultiBackend *from(wlr_backend *handle);
+#if WLR_VERSION_MINOR > 17
+    static QWMultiBackend *create(wl_event_loop *eventloop, QObject *parent = nullptr);
+#else
     static QWMultiBackend *create(QWDisplay *display, QObject *parent = nullptr);
+#endif
 
     bool add(QWBackend *backend);
     void remove(QWBackend *backend);
@@ -96,7 +101,11 @@ class QW_EXPORT QWDrmBackend : public QWBackend
 public:
     static QWDrmBackend *get(wlr_backend *handle);
     static QWDrmBackend *from(wlr_backend *handle);
+#if WLR_VERSION_MINOR > 17
+    static QWDrmBackend *create(wlr_session *session, wlr_device *dev, QWBackend *parent);
+#else
     static QWDrmBackend *create(QWDisplay *display, wlr_session *session, wlr_device *dev, QWBackend *parent);
+#endif
 
     static bool isDrmOutput(QWOutput *output);
     static uint32_t connectorGetId(QWOutput *output);
@@ -119,7 +128,9 @@ class QW_EXPORT QWWaylandBackend : public QWBackend
 public:
     static QWWaylandBackend *get(wlr_backend *handle);
     static QWWaylandBackend *from(wlr_backend *handle);
-#if WLR_VERSION_MINOR > 16
+#if WLR_VERSION_MINOR > 17
+    static QWWaylandBackend *create(wl_event_loop *eventloop, wl_display *remote_display, QObject *parent = nullptr);
+#elif WLR_VERSION_MINOR > 16
     static QWWaylandBackend *create(QWDisplay *display, wl_display *remote_display, QObject *parent = nullptr);
 #else
     static QWWaylandBackend *create(QWDisplay *display, const char *remote, QObject *parent = nullptr);
@@ -144,7 +155,11 @@ class QW_EXPORT QWX11Backend : public QWBackend
 public:
     static QWX11Backend *get(wlr_backend *handle);
     static QWX11Backend *from(wlr_backend *handle);
+#if WLR_VERSION_MINOR > 17
+    static QWX11Backend *create(wl_event_loop *eventloop, const char *x11Display, QObject *parent = nullptr);
+#else
     static QWX11Backend *create(QWDisplay *display, const char *x11Display, QObject *parent = nullptr);
+#endif
 
     QWOutput *createOutput();
 
@@ -163,7 +178,11 @@ class QW_EXPORT QWLibinputBackend : public QWBackend
 public:
     static QWLibinputBackend *get(wlr_backend *handle);
     static QWLibinputBackend *from(wlr_backend *handle);
+#if WLR_VERSION_MINOR > 17
+    static QWLibinputBackend *create(wlr_session *session, QObject *parent = nullptr);
+#else
     static QWLibinputBackend *create(QWDisplay *display, wlr_session *session, QObject *parent = nullptr);
+#endif
 
     static bool isLibinputDevice(QWInputDevice *device);
     static libinput_device *getDeviceHandle(QWInputDevice *dev);
@@ -179,7 +198,11 @@ class QW_EXPORT QWHeadlessBackend : public QWBackend
 public:
     static QWHeadlessBackend *get(wlr_backend *handle);
     static QWHeadlessBackend *from(wlr_backend *handle);
+#if WLR_VERSION_MINOR > 17
+    static QWHeadlessBackend *create(wl_event_loop *eventloop, QObject *parent = nullptr);
+#else
     static QWHeadlessBackend *create(QWDisplay *display, QObject *parent = nullptr);
+#endif
 
     QWOutput *addOutput(unsigned int width, unsigned int height);
     static bool isHeadlessOutput(QWOutput *output);

--- a/src/qwdisplay.cpp
+++ b/src/qwdisplay.cpp
@@ -87,4 +87,9 @@ void QWDisplay::terminate()
     wl_display_terminate(handle());
 }
 
+wl_event_loop *QWDisplay::eventLoop() const
+{
+    return wl_display_get_event_loop(handle());
+}
+
 QW_END_NAMESPACE

--- a/src/qwdisplay.h
+++ b/src/qwdisplay.h
@@ -7,6 +7,7 @@
 #include <QObject>
 
 struct wl_display;
+struct wl_event_loop;
 
 QT_BEGIN_NAMESPACE
 class QThread;
@@ -32,6 +33,8 @@ public:
 
     void exec();
     void start(QThread *thread);
+
+    wl_event_loop *eventLoop() const;
 
 Q_SIGNALS:
     void beforeDestroy(QWDisplay *self);

--- a/src/render/qwrenderer.cpp
+++ b/src/render/qwrenderer.cpp
@@ -35,9 +35,7 @@ public:
         Q_ASSERT(!map.contains(handle));
         map.insert(handle, qq);
         sc.connect(&handle->events.destroy, this, &QWRendererPrivate::on_destroy);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.lost, this, &QWRendererPrivate::on_lost);
-#endif
     }
     ~QWRendererPrivate() {
         if (!m_handle)
@@ -56,9 +54,7 @@ public:
     }
 
     void on_destroy(void *);
-#if WLR_VERSION_MINOR > 16
     void on_lost(void *);
-#endif
 
     static QHash<void*, QWRenderer*> map;
     QW_DECLARE_PUBLIC(QWRenderer)
@@ -73,12 +69,10 @@ void QWRendererPrivate::on_destroy(void *)
     delete q_func();
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWRendererPrivate::on_lost(void *)
 {
     Q_EMIT q_func()->lost();
 }
-#endif
 
 QWRenderer *QWRenderer::get(wlr_renderer *handle)
 {

--- a/src/render/qwrenderer.cpp
+++ b/src/render/qwrenderer.cpp
@@ -17,6 +17,9 @@ extern "C" {
 #include <wayland-server-core.h>
 #define static
 #include <wlr/render/wlr_renderer.h>
+#if WLR_VERSION_MINOR >= 18
+#include <wlr/render/pass.h>
+#endif
 #undef static
 #include <wlr/util/box.h>
 }
@@ -104,31 +107,40 @@ QWRenderer::QWRenderer(wlr_renderer *handle, bool isOwner)
 
 }
 
-#if WLR_VERSION_MINOR > 16
+#if WLR_VERSION_MINOR < 18
 bool QWRenderer::begin(uint32_t width, uint32_t height)
 {
     Q_D(QWRenderer);
     return wlr_renderer_begin(handle(), width, height);
 }
-#else
-void QWRenderer::begin(uint32_t width, uint32_t height)
-{
-    Q_D(QWRenderer);
-    wlr_renderer_begin(handle(), width, height);
-}
 #endif
 
+#if WLR_VERSION_MINOR < 18
 bool QWRenderer::begin(QWBuffer *buffer)
 {
     Q_D(QWRenderer);
     return wlr_renderer_begin_with_buffer(handle(), buffer->handle());
 }
-
+# else
+wlr_render_pass* QWRenderer::begin(QWBuffer *buffer, const wlr_buffer_pass_options *options)
+{
+    Q_D(QWRenderer);
+    return wlr_renderer_begin_buffer_pass(handle(), buffer->handle(), options);
+}
+#endif
+#if WLR_VERSION_MINOR > 17
+void QWRenderer::end(wlr_render_pass *pass)
+{
+    Q_D(QWRenderer);
+    wlr_render_pass_submit(pass);
+}
+#else
 void QWRenderer::end()
 {
     Q_D(QWRenderer);
     wlr_renderer_end(handle());
 }
+#endif
 
 bool QWRenderer::initWlDisplay(QWDisplay *display)
 {
@@ -252,12 +264,14 @@ const wlr_drm_format_set *QWRenderer::getDmabufTextureFormats() const
     return wlr_renderer_get_dmabuf_texture_formats(handle());
 }
 
+#if WLR_VERSION_MINOR < 18
 bool QWRenderer::readPixels(uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
                             uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data) const
 {
     Q_D(const QWRenderer);
     return wlr_renderer_read_pixels(handle(), fmt, stride, width, height, src_x, src_y, dst_x, dst_y, data);
 }
+#endif
 
 int QWRenderer::getDrmFd() const
 {

--- a/src/render/qwrenderer.h
+++ b/src/render/qwrenderer.h
@@ -14,6 +14,7 @@ struct wlr_box;
 struct wlr_fbox;
 struct wlr_drm_format_set;
 struct wl_display;
+struct wlr_render_texture_options;
 
 QW_BEGIN_NAMESPACE
 
@@ -39,8 +40,14 @@ public:
 #else
     void begin(uint32_t width, uint32_t height);
 #endif
+#if WLR_VERSION_MINOR > 17
+    // TODO: use QWRenderPass
+    wlr_render_pass* begin(QWBuffer *buffer, const wlr_buffer_pass_options *options);
+    void end(wlr_render_pass* pass);
+#else
     bool begin(QWBuffer *buffer);
     void end();
+#endif
 
     bool initWlDisplay(QWDisplay *display);
     bool initWlShm(QWDisplay *display);
@@ -61,8 +68,10 @@ public:
 
     const uint32_t *getShmTextureFormats(size_t *len) const;
     const wlr_drm_format_set *getDmabufTextureFormats() const;
+#if WLR_VERSION_MINOR < 18
     bool readPixels(uint32_t fmt, uint32_t stride, uint32_t width, uint32_t height,
                     uint32_t src_x, uint32_t src_y, uint32_t dst_x, uint32_t dst_y, void *data) const;
+#endif
     int getDrmFd() const;
 
     template<class Interface, typename... Args>

--- a/src/render/qwrenderer.h
+++ b/src/render/qwrenderer.h
@@ -35,11 +35,8 @@ public:
     static QWRenderer *get(wlr_renderer *handle);
     static QWRenderer *from(wlr_renderer *handle);
     static QWRenderer *autoCreate(QWBackend *backend);
-#if WLR_VERSION_MINOR > 16
     bool begin(uint32_t width, uint32_t height);
-#else
-    void begin(uint32_t width, uint32_t height);
-#endif
+
 #if WLR_VERSION_MINOR > 17
     // TODO: use QWRenderPass
     wlr_render_pass* begin(QWBuffer *buffer, const wlr_buffer_pass_options *options);
@@ -85,9 +82,7 @@ public:
 
 Q_SIGNALS:
     void beforeDestroy(QWRenderer *self);
-#if WLR_VERSION_MINOR > 16
     void lost();
-#endif
 
 private:
     QWRenderer(wlr_renderer *handle, bool isOwner);

--- a/src/types/qwbuffer.cpp
+++ b/src/types/qwbuffer.cpp
@@ -75,13 +75,7 @@ QWBuffer *QWBuffer::from(wlr_buffer *handle)
 
 QWBuffer *QWBuffer::from(wl_resource *resource)
 {
-#if WLR_VERSION_MINOR > 16
     auto handle = wlr_buffer_try_from_resource(resource);
-#else
-    if (!wlr_resource_is_buffer(resource))
-        return nullptr;
-    auto handle = wlr_buffer_from_resource(resource);
-#endif
     if (!handle)
         return nullptr;
     return from(handle);

--- a/src/types/qwbuffer.h
+++ b/src/types/qwbuffer.h
@@ -80,10 +80,6 @@ public:
 
     static QWClientBuffer *from(wlr_client_buffer *handle);
     static QWClientBuffer *get(QWBuffer *buffer);
-#if WLR_VERSION_MINOR <= 16
-    static QWClientBuffer *create(QWBuffer *buffer, QWRenderer *renderer);
-    bool applyDamage(QWBuffer *next, pixman_region32 *damage);
-#endif
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwclientbuffer.cpp
+++ b/src/types/qwclientbuffer.cpp
@@ -26,17 +26,5 @@ QWClientBuffer *QWClientBuffer::get(QWBuffer *buffer)
     return from(handle);
 }
 
-#if WLR_VERSION_MINOR <= 16
-QWClientBuffer *QWClientBuffer::create(QWBuffer *buffer, QWRenderer *renderer)
-{
-    auto *handle = wlr_client_buffer_create(buffer->handle(), renderer->handle());
-    return from(handle);
-}
-
-bool QWClientBuffer::applyDamage(QWBuffer *next, pixman_region32 *damage)
-{
-    return wlr_client_buffer_apply_damage(handle(), next->handle(), damage);
-}
-#endif
 
 QW_END_NAMESPACE

--- a/src/types/qwcompositor.cpp
+++ b/src/types/qwcompositor.cpp
@@ -93,12 +93,7 @@ QWCompositor *QWCompositor::from(wlr_compositor *handle)
 
 QWCompositor *QWCompositor::create(QWDisplay *display, QWRenderer *renderer, uint32_t version)
 {
-#if WLR_VERSION_MINOR > 16
     auto compositor = wlr_compositor_create(display->handle(), version, renderer->handle());
-#else
-    Q_UNUSED(version)
-    auto compositor = wlr_compositor_create(display->handle(), renderer->handle());
-#endif
     if (!compositor)
         return nullptr;
     return new QWCompositor(compositor, true);
@@ -118,13 +113,11 @@ public:
         sc.connect(&handle->events.client_commit, this, &QWSurfacePrivate::on_client_commit);
         sc.connect(&handle->events.commit, this, &QWSurfacePrivate::on_commit);
         sc.connect(&handle->events.new_subsurface, this, &QWSurfacePrivate::on_new_subsurface);
-#if WLR_VERSION_MINOR > 16
-    #if WLR_VERSION_MINOR < 18
+#if WLR_VERSION_MINOR < 18
         sc.connect(&handle->events.precommit, this, &QWSurfacePrivate::on_precommit);
-    #endif
+#endif
         sc.connect(&handle->events.map, this, &QWSurfacePrivate::on_map);
         sc.connect(&handle->events.unmap, this, &QWSurfacePrivate::on_unmap);
-#endif
     }
     ~QWSurfacePrivate() {
         if (!m_handle)
@@ -144,11 +137,10 @@ public:
     void on_client_commit(void *);
     void on_commit(void *);
     void on_new_subsurface(void *);
-#if WLR_VERSION_MINOR > 16
     void on_precommit(void *);
     void on_map(void *);
     void on_unmap(void *);
-#endif
+
     static QHash<void*, QWSurface*> map;
     QW_DECLARE_PUBLIC(QWSurface)
     QWSignalConnector sc;
@@ -179,8 +171,6 @@ void QWSurfacePrivate::on_new_subsurface(void *data)
     Q_EMIT q_func()->newSubsurface(QWSubsurface::from(handle));
 }
 
-#if WLR_VERSION_MINOR > 16
-
 void QWSurfacePrivate::on_precommit(void *data)
 {
     Q_EMIT q_func()->precommit(reinterpret_cast<wlr_surface_state*>(data));
@@ -195,8 +185,6 @@ void QWSurfacePrivate::on_unmap(void *)
 {
     Q_EMIT q_func()->unmapped();
 }
-
-#endif
 
 QWSurface::QWSurface(wlr_surface *handle, bool isOwner)
     : QObject(nullptr)
@@ -225,12 +213,6 @@ QWSurface *QWSurface::from(wl_resource *resource)
     return from(handle);
 }
 
-#if WLR_VERSION_MINOR <= 16
-void QWSurface::destroyRoleObject()
-{
-    wlr_surface_destroy_role_object(handle());
-}
-#endif
 void QWSurface::forEachSurface(wlr_surface_iterator_func_t iterator, void *userData) const
 {
     wlr_surface_for_each_surface(handle(), iterator, userData);
@@ -316,7 +298,6 @@ void QWSurface::unlockCached(uint32_t seq)
     wlr_surface_unlock_cached(handle(), seq);
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWSurface::setPreferredBufferScale(int32_t scale)
 {
     wlr_surface_set_preferred_buffer_scale(handle(), scale);
@@ -341,6 +322,5 @@ void QWSurface::unmap()
 {
     wlr_surface_unmap(handle());
 }
-#endif
 
 QW_END_NAMESPACE

--- a/src/types/qwcompositor.cpp
+++ b/src/types/qwcompositor.cpp
@@ -119,7 +119,9 @@ public:
         sc.connect(&handle->events.commit, this, &QWSurfacePrivate::on_commit);
         sc.connect(&handle->events.new_subsurface, this, &QWSurfacePrivate::on_new_subsurface);
 #if WLR_VERSION_MINOR > 16
+    #if WLR_VERSION_MINOR < 18
         sc.connect(&handle->events.precommit, this, &QWSurfacePrivate::on_precommit);
+    #endif
         sc.connect(&handle->events.map, this, &QWSurfacePrivate::on_map);
         sc.connect(&handle->events.unmap, this, &QWSurfacePrivate::on_unmap);
 #endif

--- a/src/types/qwcompositor.h
+++ b/src/types/qwcompositor.h
@@ -62,9 +62,7 @@ public:
     static QWSurface *get(wlr_surface *handle);
     static QWSurface *from(wlr_surface *handle);
     static QWSurface *from(wl_resource *resource);
-#if WLR_VERSION_MINOR <= 16
-    void destroyRoleObject();
-#endif
+
     void forEachSurface(wlr_surface_iterator_func_t iterator, void *userData) const;
     QRectF getBufferSourceBox() const;
     void getEffectiveDamage(pixman_region32_t *damage) const;
@@ -79,13 +77,11 @@ public:
     void sendLeave(QWOutput *output);
     QWSurface *surfaceAt(const QPointF &xpos, QPointF *subPos = nullptr) const;
     void unlockCached(uint32_t seq);
-#if WLR_VERSION_MINOR > 16
     void setPreferredBufferScale(int32_t scale);
     void setPreferredBufferTransform(wl_output_transform_t transform);
     void setRole(const wlr_surface_role *role, wl_resource *errorResource, uint32_t errorCode);
     void map();
     void unmap();
-#endif
 
 Q_SIGNALS:
     void beforeDestroy(QWSurface *self);
@@ -94,9 +90,7 @@ Q_SIGNALS:
     void newSubsurface(QWSubsurface *surface);
     void mapped();
     void unmapped();
-#if WLR_VERSION_MINOR > 16
     void precommit(const wlr_surface_state *state);
-#endif
 
 private:
     QWSurface(wlr_surface *handle, bool isOwner);

--- a/src/types/qwcursor.cpp
+++ b/src/types/qwcursor.cpp
@@ -256,7 +256,6 @@ void QWCursor::move(QWInputDevice *dev, const QPointF &deltaPos)
     wlr_cursor_move(handle(), dev ? dev->handle() : nullptr, deltaPos.x(), deltaPos.y());
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWCursor::setBuffer(QWBuffer *buffer, const QPoint &hotspot, float scale)
 {
     wlr_cursor_set_buffer(handle(), buffer->handle(),
@@ -272,14 +271,6 @@ void QWCursor::unsetImage()
 {
     wlr_cursor_unset_image(handle());
 }
-#else
-void QWCursor::setImage(const QImage &image, const QPoint &hotspot)
-{
-    wlr_cursor_set_image(handle(), reinterpret_cast<const uint8_t*>(image.constBits()),
-                         image.bytesPerLine(), image.width(), image.height(),
-                         hotspot.x(), hotspot.y(), image.devicePixelRatioF());
-}
-#endif
 
 void QWCursor::setSurface(QWSurface *surface, const QPoint &hotspot)
 {

--- a/src/types/qwcursor.h
+++ b/src/types/qwcursor.h
@@ -57,13 +57,10 @@ public:
     void warpClosest(QWInputDevice *dev, const QPointF &pos);
     void warpAbsolute(QWInputDevice *dev, const QPointF &pos);
     void move(QWInputDevice *dev, const QPointF &deltaPos);
-#if WLR_VERSION_MINOR > 16
+
     void setBuffer(QWBuffer *buffer, const QPoint &hotspot, float scale);
     void setXCursor(QWXCursorManager *manager, const char *name);
     void unsetImage();
-#else
-    void setImage(const QImage &image, const QPoint &hotspot);
-#endif
     void setSurface(QWSurface *surface, const QPoint &hotspot);
 
     void attachInputDevice(QWInputDevice *dev);

--- a/src/types/qwdrm.cpp
+++ b/src/types/qwdrm.cpp
@@ -93,13 +93,7 @@ QWDrmBuffer *QWDrmBuffer::from(wlr_drm_buffer *handle)
 
 QWDrmBuffer *QWDrmBuffer::from(wl_resource *resource)
 {
-#if WLR_VERSION_MINOR > 16
     auto *handle = wlr_drm_buffer_try_from_resource(resource);
-#else
-    if (!wlr_drm_buffer_is_resource(resource))
-        return nullptr;
-    auto *handle = wlr_drm_buffer_from_resource(resource);
-#endif
     return handle ? from(handle) : nullptr;
 }
 

--- a/src/types/qwgammacontorlv1.cpp
+++ b/src/types/qwgammacontorlv1.cpp
@@ -22,9 +22,7 @@ public:
         Q_ASSERT(!map.contains(handle));
         map.insert(handle, qq);
         sc.connect(&handle->events.destroy, this, &QWGammaControlManagerV1Private::on_destroy);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.set_gamma, this, &QWGammaControlManagerV1Private::on_set_gamma);
-#endif
     }
     ~QWGammaControlManagerV1Private() {
         if (!m_handle)
@@ -41,9 +39,7 @@ public:
     }
 
     void on_destroy(void *);
-#if WLR_VERSION_MINOR > 16
     void on_set_gamma(void *);
-#endif
 
     static QHash<void*, QWGammaControlManagerV1*> map;
     QW_DECLARE_PUBLIC(QWGammaControlManagerV1)
@@ -58,12 +54,10 @@ void QWGammaControlManagerV1Private::on_destroy(void *)
     delete q_func();
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWGammaControlManagerV1Private::on_set_gamma(void *data)
 {
     Q_EMIT q_func()->gammaChanged(reinterpret_cast<wlr_gamma_control_manager_v1_set_gamma_event*>(data));
 }
-#endif
 
 QWGammaControlManagerV1::QWGammaControlManagerV1(wlr_gamma_control_manager_v1 *handle, bool isOwner)
     : QObject(nullptr)

--- a/src/types/qwgammacontorlv1.h
+++ b/src/types/qwgammacontorlv1.h
@@ -28,9 +28,7 @@ public:
 
 Q_SIGNALS:
     void beforeDestroy(QWGammaControlManagerV1 *self);
-#if WLR_VERSION_MINOR > 16
     void gammaChanged(wlr_gamma_control_manager_v1_set_gamma_event *event);
-#endif
 
 private:
     QWGammaControlManagerV1(wlr_gamma_control_manager_v1 *handle, bool isOwner);

--- a/src/types/qwinputdevice.cpp
+++ b/src/types/qwinputdevice.cpp
@@ -77,7 +77,11 @@ QWInputDevice *QWInputDevice::from(wlr_input_device *handle)
         return QWKeyboard::fromInputDevice(handle);
     case WLR_INPUT_DEVICE_POINTER:
         return QWPointer::fromInputDevice(handle);
+#if WLR_VERSION_MINOR > 17
+    case WLR_INPUT_DEVICE_TABLET:
+#else
     case WLR_INPUT_DEVICE_TABLET_TOOL:
+#endif
         return QWTablet::fromInputDevice(handle);
     case WLR_INPUT_DEVICE_TABLET_PAD:
         return QWTabletPad::fromInputDevice(handle);

--- a/src/types/qwinputpopupsurfacev2.cpp
+++ b/src/types/qwinputpopupsurfacev2.cpp
@@ -26,10 +26,6 @@ public:
         Q_ASSERT(!map.contains(handle));
         map.insert(handle, qq);
         sc.connect(&handle->events.destroy, this, &QWInputPopupSurfaceV2Private::on_destroy);
-#if WLR_VERSION_MINOR <= 16
-        sc.connect(&handle->events.map, this, &QWInputPopupSurfaceV2Private::on_map);
-        sc.connect(&handle->events.unmap, this, &QWInputPopupSurfaceV2Private::on_unmap);
-#endif
     }
     ~QWInputPopupSurfaceV2Private() {
         if (!m_handle)
@@ -47,11 +43,6 @@ public:
 
     void on_destroy(void *);
 
-#if WLR_VERSION_MINOR <= 16
-    void on_map(void *);
-    void on_unmap(void *);
-#endif
-
     static QHash<void*, QWInputPopupSurfaceV2*> map;
     QW_DECLARE_PUBLIC(QWInputPopupSurfaceV2)
     QWSignalConnector sc;
@@ -64,18 +55,6 @@ void QWInputPopupSurfaceV2Private::on_destroy(void *)
     m_handle = nullptr;
     delete q_func();
 }
-
-#if WLR_VERSION_MINOR <= 16
-void QWInputPopupSurfaceV2Private::on_map(void *)
-{
-    Q_EMIT q_func()->surface()->mapped();
-}
-
-void QWInputPopupSurfaceV2Private::on_unmap(void *)
-{
-    Q_EMIT q_func()->surface()->unmapped();
-}
-#endif
 
 QWInputPopupSurfaceV2::QWInputPopupSurfaceV2(wlr_input_popup_surface_v2 *handle, bool isOwner)
     : QObject(nullptr)
@@ -98,13 +77,7 @@ QWInputPopupSurfaceV2 *QWInputPopupSurfaceV2::from(wlr_input_popup_surface_v2 *h
 
 QWInputPopupSurfaceV2 *QWInputPopupSurfaceV2::from(QWSurface *surface)
 {
-#if WLR_VERSION_MINOR > 16
     auto *handle = wlr_input_popup_surface_v2_try_from_wlr_surface(surface->handle());
-#else
-    if (!wlr_surface_is_input_popup_surface_v2(surface->handle()))
-        return nullptr;
-    auto *handle = wlr_input_popup_surface_v2_from_wlr_surface(surface->handle());
-#endif
     if (!handle)
         return nullptr;
     return from(handle);

--- a/src/types/qwlayershellv1.h
+++ b/src/types/qwlayershellv1.h
@@ -26,11 +26,7 @@ class QW_EXPORT QWLayerShellV1 : public QObject, public QWObject
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWLayerShellV1)
 public:
-#if WLR_VERSION_MINOR > 16
     static QWLayerShellV1 *create(QWDisplay *display, uint32_t version);
-#else
-    static QWLayerShellV1 *create(QWDisplay *display);
-#endif
     inline wlr_layer_shell_v1 *handle() const {
         return QWObject::handle<wlr_layer_shell_v1>();
     }

--- a/src/types/qwlinuxdmabuffeedbackv1.cpp
+++ b/src/types/qwlinuxdmabuffeedbackv1.cpp
@@ -19,8 +19,6 @@ QWLinuxDmabufFeedbackV1 *QWLinuxDmabufFeedbackV1::from(wlr_linux_dmabuf_feedback
     return reinterpret_cast<QWLinuxDmabufFeedbackV1*>(handle);
 }
 
-#if WLR_VERSION_MINOR > 16
-
 void QWLinuxDmabufFeedbackV1::finish()
 {
     wlr_linux_dmabuf_feedback_v1_finish(handle());
@@ -30,7 +28,5 @@ bool QWLinuxDmabufFeedbackV1::initWithOptions(const wlr_linux_dmabuf_feedback_v1
 {
     return wlr_linux_dmabuf_feedback_v1_init_with_options(handle(), options);
 }
-
-#endif // WLR_VERSION_MINOR > 16
 
 QW_END_NAMESPACE

--- a/src/types/qwlinuxdmabufv1.cpp
+++ b/src/types/qwlinuxdmabufv1.cpp
@@ -72,8 +72,6 @@ QWLinuxDmabufV1 *QWLinuxDmabufV1::from(wlr_linux_dmabuf_v1 *handle)
     return new QWLinuxDmabufV1(handle, false);
 }
 
-#if WLR_VERSION_MINOR > 16
-
 QWLinuxDmabufV1 *QWLinuxDmabufV1::create(QWDisplay *display, uint32_t version, const QWLinuxDmabufFeedbackV1 *defaultFeedback)
 {
     auto *handle = wlr_linux_dmabuf_v1_create(display->handle(), version, defaultFeedback->handle());
@@ -89,17 +87,5 @@ QWLinuxDmabufV1 *QWLinuxDmabufV1::create(QWDisplay *display, uint32_t version, Q
         return nullptr;
     return new QWLinuxDmabufV1(handle, true);
 }
-
-#else
-
-QWLinuxDmabufV1 *QWLinuxDmabufV1::create(QWDisplay *display, QWRenderer *renderer)
-{
-    auto *handle = wlr_linux_dmabuf_v1_create(display->handle(), renderer->handle());
-    if (!handle)
-        return nullptr;
-    return new QWLinuxDmabufV1(handle, true);
-}
-
-#endif // WLR_VERSION_MINOR > 16
 
 QW_END_NAMESPACE

--- a/src/types/qwlinuxdmabufv1.h
+++ b/src/types/qwlinuxdmabufv1.h
@@ -24,10 +24,8 @@ public:
     wlr_linux_dmabuf_feedback_v1 *handle() const;
     static QWLinuxDmabufFeedbackV1 *from(wlr_linux_dmabuf_feedback_v1 *handle);
 
-#if WLR_VERSION_MINOR > 16
     void finish();
     bool initWithOptions(const wlr_linux_dmabuf_feedback_v1_init_options *options);
-#endif // WLR_VERSION_MINOR > 16
 };
 
 class QWLinuxDmabufV1Private;
@@ -42,12 +40,8 @@ public:
 
     static QWLinuxDmabufV1 *get(wlr_linux_dmabuf_v1 *handle);
     static QWLinuxDmabufV1 *from(wlr_linux_dmabuf_v1 *handle);
-#if WLR_VERSION_MINOR > 16
     static QWLinuxDmabufV1 *create(QWDisplay *display, uint32_t version, const QWLinuxDmabufFeedbackV1 *defaultFeedback);
     static QWLinuxDmabufV1 *create(QWDisplay *display, uint32_t version, QWRenderer *renderer);
-#else
-    static QWLinuxDmabufV1 *create(QWDisplay *display, QWRenderer *renderer);
-#endif // WLR_VERSION_MINOR > 16
 
 Q_SIGNALS:
     void beforeDestroy(QWLinuxDmabufV1 *self);

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -159,12 +159,12 @@ QWOutput *QWOutput::from(wl_resource *resource)
     return from(handle);
 }
 
+#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
 void QWOutput::enable(bool enable)
 {
     wlr_output_enable(handle(), enable);
 }
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
 void QWOutput::createGlobal()
 {
     wlr_output_create_global(handle());
@@ -190,7 +190,7 @@ wlr_output_mode *QWOutput::preferredMode() const
 {
     return wlr_output_preferred_mode(handle());
 }
-
+#if WLR_VERSION_MINOR < 18
 void QWOutput::setMode(wlr_output_mode *mode)
 {
     wlr_output_set_mode(handle(), mode);
@@ -226,6 +226,17 @@ void QWOutput::setSubpixel(wl_output_subpixel_t subpixel)
     wlr_output_set_subpixel(handle(), static_cast<wl_output_subpixel>(subpixel));
 }
 
+void QWOutput::setDamage(pixman_region32 *damage)
+{
+    wlr_output_set_damage(handle(), damage);
+}
+
+void QWOutput::setGamma(size_t size, const uint16_t *r, const uint16_t *g, const uint16_t *b)
+{
+    wlr_output_set_gamma(handle(), size, r, g, b);
+}
+#endif
+
 void QWOutput::setName(const QByteArray &name)
 {
     wlr_output_set_name(handle(), name.constData());
@@ -255,31 +266,30 @@ QSize QWOutput::effectiveResolution() const
     return size;
 }
 
+#if WLR_VERSION_MINOR < 18
 bool QWOutput::attachRender(int *bufferAge)
 {
     return wlr_output_attach_render(handle(), bufferAge);
 }
+void QWOutput::attachBuffer(QWBuffer *buffer)
+{
+    wlr_output_attach_buffer(handle(), buffer->handle());
+}
+#endif
 
 void QWOutput::lockAttachRender(bool lock)
 {
     wlr_output_lock_attach_render(handle(), lock);
 }
 
-void QWOutput::attachBuffer(QWBuffer *buffer)
-{
-    wlr_output_attach_buffer(handle(), buffer->handle());
-}
-
+#if WLR_VERSION_MINOR < 18
 uint32_t QWOutput::preferredReadFormat() const
 {
     return wlr_output_preferred_read_format(handle());
 }
+#endif
 
-void QWOutput::setDamage(pixman_region32 *damage)
-{
-    wlr_output_set_damage(handle(), damage);
-}
-
+#if WLR_VERSION_MINOR < 18
 bool QWOutput::test()
 {
     return wlr_output_test(handle());
@@ -294,6 +304,7 @@ void QWOutput::rollback()
 {
     wlr_output_rollback(handle());
 }
+#endif
 
 bool QWOutput::testState(wlr_output_state *state)
 {
@@ -305,6 +316,13 @@ bool QWOutput::commitState(wlr_output_state *state)
     return wlr_output_commit_state(handle(), state);
 }
 
+#if WLR_VERSION_MINOR > 16
+void QWOutput::finishState(wlr_output_state *state)
+{
+    wlr_output_state_finish(state);
+}
+#endif
+
 void QWOutput::scheduleFrame()
 {
     wlr_output_schedule_frame(handle());
@@ -313,11 +331,6 @@ void QWOutput::scheduleFrame()
 size_t QWOutput::getGammaSize() const
 {
     return wlr_output_get_gamma_size(handle());
-}
-
-void QWOutput::setGamma(size_t size, const uint16_t *r, const uint16_t *g, const uint16_t *b)
-{
-    wlr_output_set_gamma(handle(), size, r, g, b);
 }
 
 void QWOutput::lockSoftwareCursors(bool lock)

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -39,9 +39,7 @@ public:
         sc.connect(&handle->events.present, this, &QWOutputPrivate::on_present);
         sc.connect(&handle->events.bind, this, &QWOutputPrivate::on_bind);
         sc.connect(&handle->events.description, this, &QWOutputPrivate::on_description);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.request_state, this, &QWOutputPrivate::on_request_state);
-#endif
         sc.connect(&handle->events.destroy, this, &QWOutputPrivate::on_destroy);
     }
     ~QWOutputPrivate() {
@@ -68,9 +66,7 @@ public:
     void on_present(void *data);
     void on_bind(void *data);
     void on_description(void *data);
-#if WLR_VERSION_MINOR > 16
     void on_request_state(void *data);
-#endif
     void on_destroy(void *data);
 
     static QHash<void*, QWOutput*> map;
@@ -119,12 +115,11 @@ void QWOutputPrivate::on_description(void *)
     Q_EMIT q_func()->descriptionChanged();
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWOutputPrivate::on_request_state(void *data)
 {
     Q_EMIT q_func()->requestState(static_cast<wlr_output_event_request_state*>(data));
 }
-#endif
+
 void QWOutputPrivate::on_destroy(void *)
 {
     destroy();
@@ -316,12 +311,10 @@ bool QWOutput::commitState(wlr_output_state *state)
     return wlr_output_commit_state(handle(), state);
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWOutput::finishState(wlr_output_state *state)
 {
     wlr_output_state_finish(state);
 }
-#endif
 
 void QWOutput::scheduleFrame()
 {
@@ -350,7 +343,6 @@ const wlr_drm_format_set *QWOutput::getPrimaryFormats(uint32_t bufferCaps)
     return wlr_output_get_primary_formats(handle(), bufferCaps);
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWOutput::addSoftwareCursorsToRenderPass(wlr_render_pass *render_pass, const pixman_region32_t *damage)
 {
     wlr_output_add_software_cursors_to_render_pass(handle(), render_pass, damage);
@@ -360,7 +352,6 @@ bool QWOutput::configurePrimarySwapchain(const wlr_output_state *state, wlr_swap
 {
     return wlr_output_configure_primary_swapchain(handle(), state, swapchain);
 }
-#endif
 
 void QWOutputCursor::operator delete(QWOutputCursor *p, std::destroying_delete_t)
 {
@@ -382,15 +373,6 @@ QWOutputCursor *QWOutputCursor::create(QWOutput *output)
     auto handle = wlr_output_cursor_create(output->handle());
     return from(handle);
 }
-
-#if WLR_VERSION_MINOR <= 16
-bool QWOutputCursor::setImage(const QImage &image, const QPoint &hotspot)
-{
-    return wlr_output_cursor_set_image(handle(), reinterpret_cast<const uint8_t*>(image.constBits()),
-                                       image.bitPlaneCount(), image.width(), image.height(),
-                                       hotspot.x(), hotspot.y());
-}
-#endif
 
 bool QWOutputCursor::setBuffer(QWBuffer *buffer, const QPoint &hotspot)
 {

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -60,8 +60,8 @@ public:
         return new QWOutput(i->handle(), true);
     }
 
-    void enable(bool enable);
 #if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
+    void enable(bool enable);
     void createGlobal();
 #else
     void createGlobal(QWDisplay *display);
@@ -70,6 +70,7 @@ public:
     bool initRender(QWAllocator *allocator, QWRenderer *renderer);
     wlr_output_mode *preferredMode() const;
 
+#if WLR_VERSION_MINOR < 18
     void setMode(wlr_output_mode *mode);
     void setCustomMode(const QSize &size, int32_t refresh);
     void setTransform(wl_output_transform_t wl_output_transform);
@@ -77,6 +78,8 @@ public:
     void setRenderFormat(uint32_t format);
     void setScale(float scale);
     void setSubpixel(wl_output_subpixel_t wl_output_subpixel);
+    void setDamage(pixman_region32 *damage);
+#endif
     void setName(const QByteArray &name);
     void setDescription(const QByteArray &desc);
     void scheduleDone();
@@ -84,17 +87,23 @@ public:
     QSize transformedResolution() const;
     QSize effectiveResolution() const;
 
+#if WLR_VERSION_MINOR < 18
     bool attachRender(int *bufferAge);
-    void lockAttachRender(bool lock);
     void attachBuffer(QWBuffer *buffer);
+#endif
+    void lockAttachRender(bool lock);
 
     uint32_t preferredReadFormat() const;
-    void setDamage(pixman_region32 *damage);
+#if WLR_VERSION_MINOR < 18
     bool test();
     bool commit();
     void rollback();
+#endif
     bool testState(wlr_output_state *state);
     bool commitState(wlr_output_state *state);
+#if WLR_VERSION_MINOR > 16
+    static void finishState(wlr_output_state *state);
+#endif
     void scheduleFrame();
 
     size_t getGammaSize() const;

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -101,9 +101,7 @@ public:
 #endif
     bool testState(wlr_output_state *state);
     bool commitState(wlr_output_state *state);
-#if WLR_VERSION_MINOR > 16
     static void finishState(wlr_output_state *state);
-#endif
     void scheduleFrame();
 
     size_t getGammaSize() const;
@@ -114,11 +112,8 @@ public:
 #endif
     const wlr_drm_format_set *getPrimaryFormats(uint32_t bufferCaps);
 
-#if WLR_VERSION_MINOR > 16
     void addSoftwareCursorsToRenderPass(wlr_render_pass *render_pass, const pixman_region32_t *damage);
     bool configurePrimarySwapchain(const wlr_output_state *state, wlr_swapchain **swapchain);
-#endif
-
 
 Q_SIGNALS:
     void beforeDestroy(QWOutput *self);
@@ -130,9 +125,7 @@ Q_SIGNALS:
     void present(wlr_output_event_present *event);
     void bind(wlr_output_event_bind *event);
     void descriptionChanged();
-#if WLR_VERSION_MINOR > 16
     void requestState(wlr_output_event_request_state *state);
-#endif
 
 private:
     QWOutput(wlr_output *handle, bool isOwner);
@@ -150,9 +143,6 @@ public:
     static QWOutputCursor *from(wlr_output_cursor *handle);
     static QWOutputCursor *create(QWOutput *output);
 
-#if WLR_VERSION_MINOR <= 16
-    bool setImage(const QImage &image, const QPoint &hotspot);
-#endif
     bool setBuffer(QWBuffer *buffer, const QPoint &hotspot);
     bool move(const QPointF &pos);
 };

--- a/src/types/qwoutputlayout.cpp
+++ b/src/types/qwoutputlayout.cpp
@@ -149,11 +149,7 @@ void QWOutputLayout::addAuto(QWOutput *output)
 
 void QWOutputLayout::move(QWOutput *output, const QPoint &pos)
 {
-#if WLR_VERSION_MINOR > 16
     wlr_output_layout_add(handle(), output->handle(), pos.x(), pos.y());
-#else
-    wlr_output_layout_move(handle(), output->handle(), pos.x(), pos.y());
-#endif
 }
 
 void QWOutputLayout::remove(QWOutput *output)

--- a/src/types/qwpresentation.cpp
+++ b/src/types/qwpresentation.cpp
@@ -91,7 +91,6 @@ QWPresentationFeedback *QWPresentation::surfaceSampled(QWSurface *surface) const
 #endif
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWPresentation::surfaceTexturedOnOutput(QWSurface *surface, QWOutput *output)
 {
 #if WLR_VERSION_MINOR > 17
@@ -109,14 +108,6 @@ void QWPresentation::surfaceScannedOutOnOutput(QWSurface *surface, QWOutput *out
     wlr_presentation_surface_scanned_out_on_output(handle(), surface->handle(), output->handle());
 #endif
 }
-
-#else
-
-void QWPresentation::surfaceSampledOnOutput(QWSurface *surface, QWOutput *output)
-{
-    wlr_presentation_surface_sampled_on_output(handle(), surface->handle(), output->handle());
-}
-#endif
 
 wlr_presentation_event *QWPresentationEvent::handle() const
 {

--- a/src/types/qwpresentation.cpp
+++ b/src/types/qwpresentation.cpp
@@ -84,18 +84,30 @@ QWPresentation *QWPresentation::from(wlr_presentation *handle)
 
 QWPresentationFeedback *QWPresentation::surfaceSampled(QWSurface *surface) const
 {
+#if WLR_VERSION_MINOR > 17
+    return QWPresentationFeedback::from(wlr_presentation_surface_sampled(surface->handle()));
+#else
     return QWPresentationFeedback::from(wlr_presentation_surface_sampled(handle(), surface->handle()));
+#endif
 }
 
 #if WLR_VERSION_MINOR > 16
 void QWPresentation::surfaceTexturedOnOutput(QWSurface *surface, QWOutput *output)
 {
+#if WLR_VERSION_MINOR > 17
+    wlr_presentation_surface_textured_on_output(surface->handle(), output->handle());
+#else
     wlr_presentation_surface_textured_on_output(handle(), surface->handle(), output->handle());
+#endif
 }
 
 void QWPresentation::surfaceScannedOutOnOutput(QWSurface *surface, QWOutput *output)
 {
+#if WLR_VERSION_MINOR > 17
+    wlr_presentation_surface_scanned_out_on_output(surface->handle(), output->handle());
+#else
     wlr_presentation_surface_scanned_out_on_output(handle(), surface->handle(), output->handle());
+#endif
 }
 
 #else

--- a/src/types/qwpresentation.h
+++ b/src/types/qwpresentation.h
@@ -34,12 +34,8 @@ public:
 
     QWPresentationFeedback *surfaceSampled(QWSurface *surface) const;
 
-#if WLR_VERSION_MINOR > 16
     void surfaceTexturedOnOutput(QWSurface *surface, QWOutput *output);
     void surfaceScannedOutOnOutput(QWSurface *surface, QWOutput *output);
-#else
-    void surfaceSampledOnOutput(QWSurface *surface, QWOutput *output);
-#endif
 
 Q_SIGNALS:
     void beforeDestroy(QWPresentation *self);

--- a/src/types/qwscene.cpp
+++ b/src/types/qwscene.cpp
@@ -260,21 +260,13 @@ public:
     {
         sc.connect(&handle->events.output_enter, this, &QWSceneBufferPrivate::on_output_enter);
         sc.connect(&handle->events.output_leave, this, &QWSceneBufferPrivate::on_output_leave);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.output_sample, this, &QWSceneBufferPrivate::on_output_sample);
-#else
-        sc.connect(&handle->events.output_present, this, &QWSceneBufferPrivate::on_output_present);
-#endif
         sc.connect(&handle->events.frame_done, this, &QWSceneBufferPrivate::on_frame_done);
     }
 
     void on_output_enter(void *data);
     void on_output_leave(void *data);
-#if WLR_VERSION_MINOR > 16
     void on_output_sample(void *data);
-#else
-    void on_output_present(void *data);
-#endif
     void on_frame_done(void *data);
 
     QW_DECLARE_PUBLIC(QWSceneBuffer)
@@ -290,17 +282,10 @@ void QWSceneBufferPrivate::on_output_leave(void *data)
     Q_EMIT q_func()->outputLeave(reinterpret_cast<wlr_scene_output*>(data));
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWSceneBufferPrivate::on_output_sample(void *data)
 {
     Q_EMIT q_func()->outputSample(reinterpret_cast<wlr_scene_output_sample_event*>(data));
 }
-#else
-void QWSceneBufferPrivate::on_output_present(void *data)
-{
-    Q_EMIT q_func()->outputPresent(reinterpret_cast<wlr_scene_output*>(data));
-}
-#endif
 
 void QWSceneBufferPrivate::on_frame_done(void *data)
 {
@@ -533,17 +518,10 @@ QWSceneOutput *QWSceneOutput::from(QWScene *scene, QWOutput *output)
     return new QWSceneOutput(scene, output);
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWSceneOutput::commit(const wlr_scene_output_state_options *options)
 {
     wlr_scene_output_commit(handle(), options);
 }
-#else
-void QWSceneOutput::commit()
-{
-    wlr_scene_output_commit(handle());
-}
-#endif
 
 void QWSceneOutput::sendFrameDone(timespec *now)
 {

--- a/src/types/qwscene.cpp
+++ b/src/types/qwscene.cpp
@@ -240,10 +240,12 @@ QWScene *QWScene::from(wlr_scene *handle)
     return new QWScene(handle, true, nullptr);
 }
 
+#if WLR_VERSION_MINOR < 18
 void QWScene::setPresentation(wlr_presentation *presentation)
 {
     wlr_scene_set_presentation(handle(), presentation);
 }
+#endif
 
 bool QWScene::attachOutputLayout(QWOutputLayout *outputLayout)
 {

--- a/src/types/qwscene.h
+++ b/src/types/qwscene.h
@@ -113,7 +113,10 @@ public:
     static QWScene *get(wlr_scene *handle);
     static QWScene *from(wlr_scene *handle);
 
+
+#if WLR_VERSION_MINOR<18
     void setPresentation(wlr_presentation *presentation);
+#endif
     bool attachOutputLayout(QWOutputLayout *outputLayout);
 
 private:

--- a/src/types/qwscene.h
+++ b/src/types/qwscene.h
@@ -27,11 +27,7 @@ struct pixman_region32;
 
 typedef uint32_t wl_output_transform_t;
 
-#if WLR_VERSION_MINOR <= 16
-using wlr_scene_buffer_point_accepts_input_func_t = bool (*)(wlr_scene_buffer *buffer, int sx, int sy);
-#else
 using wlr_scene_buffer_point_accepts_input_func_t = bool (*)(wlr_scene_buffer *buffer, double *sx, double *sy);
-#endif
 using wlr_scene_buffer_iterator_func_t = void (*)(wlr_scene_buffer *buffer, int sx, int sy, void *user_data);
 
 QT_BEGIN_NAMESPACE
@@ -150,11 +146,7 @@ public:
 Q_SIGNALS:
     void outputEnter(wlr_scene_output *output);
     void outputLeave(wlr_scene_output *output);
-#if WLR_VERSION_MINOR > 16
     void outputSample(wlr_scene_output_sample_event *output);
-#else
-    void outputPresent(wlr_scene_output *output);
-#endif
     void frameDone(timespec *now);
 
 private:
@@ -201,11 +193,7 @@ public:
     static QWSceneOutput *from(wlr_scene_output *handle);
     static QWSceneOutput *get(QWScene *scene, QWOutput *output);
     static QWSceneOutput *from(QWScene *scene, QWOutput *output);
-#if WLR_VERSION_MINOR > 16
     void commit(const wlr_scene_output_state_options *options);
-#else
-    void commit();
-#endif
     void sendFrameDone(timespec *now);
 
     void forEachBuffer(wlr_scene_buffer_iterator_func_t iterator, void *user_data) const;

--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -14,11 +14,16 @@ extern "C" {
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_pointer.h>
+#define static
+#include <wlr/types/wlr_compositor.h>
+#undef static
 }
 
+#if WLR_VERSION_MINOR < 18
 static_assert(std::is_same_v<wlr_axis_orientation_t, std::underlying_type_t<wlr_axis_orientation>>);
 static_assert(std::is_same_v<wlr_axis_source_t, std::underlying_type_t<wlr_axis_source>>);
 static_assert(std::is_same_v<wlr_button_state_t, std::underlying_type_t<wlr_button_state>>);
+#endif
 
 QW_BEGIN_NAMESPACE
 
@@ -279,15 +284,29 @@ bool QWSeat::pointerHasGrab() const
     return wlr_seat_pointer_has_grab(handle());
 }
 
+#if WLR_VERSION_MINOR > 17
+void QWSeat::pointerNotifyAxis(uint32_t time_msec, wl_pointer_axis orientation, double value, int32_t value_discrete, wl_pointer_axis_source source, wl_pointer_axis_relative_direction relative_direction)
+{
+    wlr_seat_pointer_notify_axis(handle(), time_msec, orientation, value, value_discrete, static_cast<wl_pointer_axis_source>(source), relative_direction);
+}
+#else
 void QWSeat::pointerNotifyAxis(uint32_t time_msec, wlr_axis_orientation_t orientation, double value, int32_t value_discrete, wlr_axis_source_t source)
 {
     wlr_seat_pointer_notify_axis(handle(), time_msec, static_cast<wlr_axis_orientation>(orientation), value, value_discrete, static_cast<wlr_axis_source>(source));
 }
+#endif
 
+#if WLR_VERSION_MINOR > 17
+void QWSeat::pointerNotifyButton(uint32_t time_msec, uint32_t button, wl_pointer_button_state state)
+{
+    wlr_seat_pointer_notify_button(handle(), time_msec, button, state);
+}
+#else
 void QWSeat::pointerNotifyButton(uint32_t time_msec, uint32_t button, wlr_button_state_t state)
 {
     wlr_seat_pointer_notify_button(handle(), time_msec, button, static_cast<wlr_button_state>(state));
 }
+#endif
 
 void QWSeat::pointerNotifyClearFocus()
 {
@@ -309,15 +328,29 @@ void QWSeat::pointerNotifyMotion(uint32_t time_msec, double sx, double sy)
     wlr_seat_pointer_notify_motion(handle(), time_msec, sx, sy);
 }
 
+#if WLR_VERSION_MINOR > 17
+void QWSeat::pointerSendAxis(uint32_t timeMsec, wl_pointer_axis orientation, double value, int32_t valueDiscrete, wl_pointer_axis_source source, wl_pointer_axis_relative_direction relative_direction)
+{
+    wlr_seat_pointer_send_axis(handle(), timeMsec, orientation, value, valueDiscrete, source, relative_direction);
+}
+#else
 void QWSeat::pointerSendAxis(uint32_t timeMsec, wlr_axis_orientation_t orientation, double value, int32_t valueDiscrete, wlr_axis_source_t source)
 {
     wlr_seat_pointer_send_axis(handle(), timeMsec, static_cast<wlr_axis_orientation>(orientation), value, valueDiscrete, static_cast<wlr_axis_source>(source));
 }
+#endif
 
+#if WLR_VERSION_MINOR > 17
+uint32_t QWSeat::pointerSendButton(uint32_t timeMsec, uint32_t button, wl_pointer_button_state state)
+{
+    return wlr_seat_pointer_send_button(handle(), timeMsec, button, state);
+}
+#else
 uint32_t QWSeat::pointerSendButton(uint32_t timeMsec, uint32_t button, wlr_button_state_t state)
 {
     return wlr_seat_pointer_send_button(handle(), timeMsec, button, static_cast<wlr_button_state>(state));
 }
+#endif
 
 void QWSeat::pointerSendFrame()
 {
@@ -369,10 +402,18 @@ bool QWSeat::touchHasGrab() const
     return wlr_seat_touch_has_grab(handle());
 }
 
+#if WLR_VERSION_MINOR > 17
+// TODO: use QWSeatClient
+void QWSeat::touchNotifyCancel(wlr_seat_client *client)
+{
+    wlr_seat_touch_notify_cancel(handle(), client);
+}
+#else
 void QWSeat::touchNotifyCancel(QWSurface *surface)
 {
     wlr_seat_touch_notify_cancel(handle(), surface->handle());
 }
+#endif
 
 uint32_t QWSeat::touchNotifyDown(QWSurface *surface, uint32_t timeMsec, int32_t touch_id, double sx, double sy)
 {
@@ -409,10 +450,18 @@ void QWSeat::touchPointFocus(QWSurface *surface, uint32_t timeMsec, int32_t touc
     wlr_seat_touch_point_focus(handle(), surface->handle(), timeMsec, touchId, sx, sy);
 }
 
+
+#if WLR_VERSION_MINOR > 17
+void QWSeat::touchSendCancel(wlr_seat_client *client)
+{
+    wlr_seat_touch_send_cancel(handle(), client);
+}
+#else
 void QWSeat::touchSendCancel(QWSurface *surface)
 {
     wlr_seat_touch_send_cancel(handle(), surface->handle());
 }
+#endif
 
 uint32_t QWSeat::touchSendDown(QWSurface *surface, uint32_t timeMsec, int32_t touchId, double sx, double sy)
 {

--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -217,17 +217,10 @@ void QWSeat::keyboardEndGrab()
     wlr_seat_keyboard_end_grab(handle());
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWSeat::keyboardEnter(QWSurface *surface, const uint32_t *keycodes, size_t numKeycodes, const wlr_keyboard_modifiers *modifiers)
 {
     wlr_seat_keyboard_enter(handle(), surface->handle(), keycodes, numKeycodes, modifiers);
 }
-#else
-void QWSeat::keyboardEnter(QWSurface *surface, uint32_t *keycodes, size_t numKeycodes, wlr_keyboard_modifiers *modifiers)
-{
-    wlr_seat_keyboard_enter(handle(), surface->handle(), keycodes, numKeycodes, modifiers);
-}
-#endif
 
 bool QWSeat::keyboardHasGrab() const
 {

--- a/src/types/qwseat.h
+++ b/src/types/qwseat.h
@@ -6,12 +6,14 @@
 #include <cstdint>
 #include <qwglobal.h>
 #include <QObject>
+#include <wayland-server-protocol.h>
 
 struct wlr_seat;
 struct wlr_seat_pointer_request_set_cursor_event;
 struct wlr_seat_request_set_selection_event;
 struct wlr_seat_request_set_primary_selection_event;
 struct wlr_seat_request_start_drag_event;
+struct wlr_seat_client;
 struct wlr_drag;
 struct wlr_data_source;
 struct wlr_keyboard_modifiers;
@@ -20,9 +22,12 @@ struct wlr_seat_pointer_grab;
 struct wlr_seat_touch_grab;
 struct wlr_touch_point;
 
+#if WLR_VERSION_MINOR < 18
 typedef uint32_t wlr_axis_orientation_t;
 typedef uint32_t wlr_axis_source_t;
 typedef uint32_t wlr_button_state_t;
+#endif
+
 
 QW_BEGIN_NAMESPACE
 
@@ -67,14 +72,26 @@ public:
     void pointerEndGrab();
     void pointerEnter(QWSurface *surface, double sx, double sy);
     bool pointerHasGrab() const;
+#if WLR_VERSION_MINOR > 17
+    void pointerNotifyAxis(uint32_t time_msec, wl_pointer_axis orientation, double value, int32_t value_discrete, wl_pointer_axis_source source,
+        wl_pointer_axis_relative_direction relative_direction = wl_pointer_axis_relative_direction::WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
+    void pointerNotifyButton(uint32_t time_msec, uint32_t button, wl_pointer_button_state state);
+#else
     void pointerNotifyAxis(uint32_t time_msec, wlr_axis_orientation_t orientation, double value, int32_t value_discrete, wlr_axis_source_t source);
     void pointerNotifyButton(uint32_t time_msec, uint32_t button, wlr_button_state_t state);
+#endif
     void pointerNotifyClearFocus();
     void pointerNotifyEnter(QWSurface *surface, double sx, double sy);
     void pointerNotifyFrame();
     void pointerNotifyMotion(uint32_t time_msec, double sx, double sy);
+#if WLR_VERSION_MINOR > 17
+    void pointerSendAxis(uint32_t timeMsec, wl_pointer_axis orientation, double value, int32_t valueDiscrete, wl_pointer_axis_source source,
+        wl_pointer_axis_relative_direction relative_direction = wl_pointer_axis_relative_direction::WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
+    uint32_t pointerSendButton(uint32_t timeMsec, uint32_t button, wl_pointer_button_state state);
+#else
     void pointerSendAxis(uint32_t timeMsec, wlr_axis_orientation_t orientation, double value, int32_t valueDiscrete, wlr_axis_source_t source);
     uint32_t pointerSendButton(uint32_t timeMsec, uint32_t button, wlr_button_state_t state);
+#endif
     void pointerSendFrame();
     void pointerSendMotion(uint32_t timeMsec, double sx, double sy);
     void pointerStartGrab(wlr_seat_pointer_grab *grab);
@@ -85,7 +102,12 @@ public:
     void touchEndGrab();
     wlr_touch_point *touchGetPoint(int32_t touchId) const;
     bool touchHasGrab() const;
+
+#if WLR_VERSION_MINOR > 17
+    void touchNotifyCancel(wlr_seat_client *client);
+#else
     void touchNotifyCancel(QWSurface *surface);
+#endif
     uint32_t touchNotifyDown(QWSurface *surface, uint32_t timeMsec, int32_t touch_id, double sx, double sy);
     void touchNotifyFrame();
     void touchNotifyMotion(uint32_t timeMsec, int32_t touchId, double sx, double sy);
@@ -93,7 +115,11 @@ public:
     int touchNumPoints();
     void touchPointClearFocus(uint32_t timeMsec, int32_t touchId);
     void touchPointFocus(QWSurface *surface, uint32_t timeMsec, int32_t touchId, double sx, double sy);
+#if WLR_VERSION_MINOR > 17
+    void touchSendCancel(wlr_seat_client *client);
+#else
     void touchSendCancel(QWSurface *surface);
+#endif
     uint32_t touchSendDown(QWSurface *surface, uint32_t timeMsec, int32_t touchId, double sx, double sy);
     void touchSendFrame();
     void touchSendMotion(uint32_t timeMsec, int32_t touchId, double sx, double sy);

--- a/src/types/qwseat.h
+++ b/src/types/qwseat.h
@@ -56,11 +56,7 @@ public:
     void setSelection(wlr_data_source *source, uint32_t serial);
     void keyboardClearFocus();
     void keyboardEndGrab();
-#if WLR_VERSION_MINOR > 16
     void keyboardEnter(QWSurface *surface, const uint32_t keycodes[], size_t numKeycodes, const wlr_keyboard_modifiers *modifiers);
-#else
-    void keyboardEnter(QWSurface *surface, uint32_t keycodes[], size_t numKeycodes, wlr_keyboard_modifiers *modifiers);
-#endif
     bool keyboardHasGrab() const;
     void keyboardNotifyClearFocus();
     void keyboardNotifyEnter(QWSurface *surface, uint32_t keycodes[], size_t numKeycodes, wlr_keyboard_modifiers *modifiers);

--- a/src/types/qwsubcompositor.cpp
+++ b/src/types/qwsubcompositor.cpp
@@ -140,12 +140,10 @@ QWSubsurface *QWSubsurface::from(wlr_subsurface *handle)
     return new QWSubsurface(handle, false);
 }
 
-#if WLR_VERSION_MINOR > 16
 QWSubsurface *QWSubsurface::tryFrom(QWSurface *surface)
 {
     auto handle = wlr_subsurface_try_from_wlr_surface(surface->handle());
     return handle ? from(handle) : nullptr;
 }
-#endif
 
 QW_END_NAMESPACE

--- a/src/types/qwsubcompositor.h
+++ b/src/types/qwsubcompositor.h
@@ -48,9 +48,7 @@ public:
 
     static QWSubsurface *get(wlr_subsurface *handle);
     static QWSubsurface *from(wlr_subsurface *handle);
-#if WLR_VERSION_MINOR > 16
     static QWSubsurface *tryFrom(QWSurface *surface);
-#endif
 
 Q_SIGNALS:
     void beforeDestroy(QWSubsurface *self);

--- a/src/types/qwxcursormanager.cpp
+++ b/src/types/qwxcursormanager.cpp
@@ -43,11 +43,4 @@ wlr_xcursor *QWXCursorManager::getXCursor(const char *name, float scale) const
     return wlr_xcursor_manager_get_xcursor(handle(), name, scale);
 }
 
-#if WLR_VERSION_MINOR <= 16
-void QWXCursorManager::setCursor(const char *name, QWCursor *cursor)
-{
-    wlr_xcursor_manager_set_cursor_image(handle(), name, cursor->handle());
-}
-#endif
-
 QW_END_NAMESPACE

--- a/src/types/qwxcursormanager.h
+++ b/src/types/qwxcursormanager.h
@@ -26,9 +26,6 @@ public:
 
     bool load(float scale);
     wlr_xcursor *getXCursor(const char *name, float scale) const;
-#if WLR_VERSION_MINOR <= 16
-    void setCursor(const char *name, QWCursor *cursor);
-#endif
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwxdgactivationv1.cpp
+++ b/src/types/qwxdgactivationv1.cpp
@@ -23,9 +23,7 @@ public:
         map.insert(handle, qq);
         sc.connect(&handle->events.destroy, this, &QWXdgActivationV1Private::on_destroy);
         sc.connect(&handle->events.request_activate, this, &QWXdgActivationV1Private::on_request_activate);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.new_token, this, &QWXdgActivationV1Private::on_new_token);
-#endif
     }
     ~QWXdgActivationV1Private() {
         if (!m_handle)
@@ -43,9 +41,7 @@ public:
 
     void on_destroy(void *);
     void on_request_activate(wlr_xdg_activation_v1_request_activate_event *);
-#if WLR_VERSION_MINOR > 16
     void on_new_token(wlr_xdg_activation_token_v1 *);
-#endif
 
     static QHash<void*, QWXdgActivationV1*> map;
     QW_DECLARE_PUBLIC(QWXdgActivationV1)
@@ -65,12 +61,10 @@ void QWXdgActivationV1Private::on_request_activate(wlr_xdg_activation_v1_request
     Q_EMIT q_func()->requestActivate(event);
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWXdgActivationV1Private::on_new_token(wlr_xdg_activation_token_v1 *token)
 {
     Q_EMIT q_func()->newToken(QWXdgActivationTokenV1::from(token));
 }
-#endif
 
 QWXdgActivationV1::QWXdgActivationV1(wlr_xdg_activation_v1 *handle, bool isOwner)
     : QObject(nullptr)

--- a/src/types/qwxdgactivationv1.h
+++ b/src/types/qwxdgactivationv1.h
@@ -57,9 +57,7 @@ public:
 Q_SIGNALS:
     void beforeDestroy(QWXdgActivationV1 *self);
     void requestActivate(wlr_xdg_activation_v1_request_activate_event *);
-#if WLR_VERSION_MINOR > 16
     void newToken(QWXdgActivationTokenV1 *);
-#endif
 
 private:
     QWXdgActivationV1(wlr_xdg_activation_v1 *handle, bool isOwner);

--- a/src/types/qwxdgshell.cpp
+++ b/src/types/qwxdgshell.cpp
@@ -128,10 +128,6 @@ public:
 #endif
         sc.connect(&handle->events.ping_timeout, this, &QWXdgSurfacePrivate::on_ping_timeout);
         sc.connect(&handle->events.new_popup, this, &QWXdgSurfacePrivate::on_new_popup);
-#if WLR_VERSION_MINOR <= 16
-        sc.connect(&handle->events.map, this, &QWXdgSurfacePrivate::on_map);
-        sc.connect(&handle->events.unmap, this, &QWXdgSurfacePrivate::on_unmap);
-#endif
         sc.connect(&handle->events.configure, this, &QWXdgSurfacePrivate::on_configure);
         sc.connect(&handle->events.ack_configure, this, &QWXdgSurfacePrivate::on_ack_configure);
 #if WLR_VERSION_MINOR >= 18
@@ -157,10 +153,6 @@ public:
     void on_destroy(void *);
     void on_ping_timeout(void *);
     void on_new_popup(wlr_xdg_popup *data);
-#if WLR_VERSION_MINOR <= 16
-    void on_map(void *);
-    void on_unmap(void *);
-#endif
     void on_configure(void *data);
     void on_ack_configure(void *data);
 
@@ -186,18 +178,6 @@ void QWXdgSurfacePrivate::on_new_popup(wlr_xdg_popup *data)
 {
     Q_EMIT q_func()->newPopup(QWXdgPopup::from(data));
 }
-
-#if WLR_VERSION_MINOR <= 16
-void QWXdgSurfacePrivate::on_map(void *)
-{
-    Q_EMIT q_func()->surface()->mapped();
-}
-
-void QWXdgSurfacePrivate::on_unmap(void *)
-{
-    Q_EMIT q_func()->surface()->unmapped();
-}
-#endif
 
 void QWXdgSurfacePrivate::on_configure(void *data)
 {
@@ -237,13 +217,7 @@ QWXdgSurface *QWXdgSurface::from(wl_resource *resource)
 
 QWXdgSurface *QWXdgSurface::from(wlr_surface *surface)
 {
-#if WLR_VERSION_MINOR > 16
     auto handle = wlr_xdg_surface_try_from_wlr_surface(surface);
-#else
-    if (!wlr_surface_is_xdg_surface(surface))
-        return nullptr;
-    auto handle = wlr_xdg_surface_from_wlr_surface(surface);
-#endif
     if (!handle)
         return nullptr;
 

--- a/src/types/qwxdgshell.cpp
+++ b/src/types/qwxdgshell.cpp
@@ -111,6 +111,9 @@ public:
 #endif
         sc.connect(&handle->events.configure, this, &QWXdgSurfacePrivate::on_configure);
         sc.connect(&handle->events.ack_configure, this, &QWXdgSurfacePrivate::on_ack_configure);
+#if WLR_VERSION_MINOR >= 18
+        sc.connect(&handle->surface->events.commit, q_func(), &QWXdgSurface::commit);
+#endif
     }
     ~QWXdgSurfacePrivate() {
         if (!m_handle)

--- a/src/types/qwxdgshell.h
+++ b/src/types/qwxdgshell.h
@@ -41,6 +41,10 @@ public:
 Q_SIGNALS:
     void beforeDestroy(QWXdgShell *self);
     void newSurface(wlr_xdg_surface *surface);
+#if WLR_VERSION_MINOR >= 18
+    void newToplevel(wlr_xdg_toplevel *surface);
+    void newPopup(wlr_xdg_popup *surface);
+#endif
 
 private:
     QWXdgShell(wlr_xdg_shell *handle, bool isOwner);
@@ -112,6 +116,9 @@ public:
 
 Q_SIGNALS:
     void reposition();
+#if WLR_VERSION_MINOR >= 18
+    void beforeDestroy(QWXdgPopup *self);
+#endif
 
 private:
     QWXdgPopup(wlr_xdg_popup *handle, bool isOwner);
@@ -152,6 +159,9 @@ Q_SIGNALS:
     void parentChanged(QWXdgToplevel *newParent);
     void titleChanged(char *newTitle);
     void appidChanged(char *newAppid);
+#if WLR_VERSION_MINOR >= 18
+    void beforeDestroy(QWXdgToplevel *self);
+#endif
 
 private:
     QWXdgToplevel(wlr_xdg_toplevel *handle, bool isOwner);

--- a/src/types/qwxdgshell.h
+++ b/src/types/qwxdgshell.h
@@ -83,6 +83,7 @@ Q_SIGNALS:
     void newPopup(QWXdgPopup *popup);
     void configure(wlr_xdg_surface_configure *conf);
     void ackConfigure(wlr_xdg_surface_configure *conf);
+    void commit();
 
 protected:
     QWXdgSurface(QWXdgSurfacePrivate &dd);

--- a/src/types/qwxwaylandserver.cpp
+++ b/src/types/qwxwaylandserver.cpp
@@ -21,10 +21,8 @@ public:
         Q_ASSERT(!map.contains(handle));
         map.insert(handle, qq);
         sc.connect(&handle->events.destroy, this, &QWXWaylandServerPrivate::on_destroy);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.start, this, &QWXWaylandServerPrivate::on_start);
         sc.connect(&handle->events.ready, this, &QWXWaylandServerPrivate::on_ready);
-#endif
     }
     ~QWXWaylandServerPrivate() {
         if (!m_handle)
@@ -43,10 +41,8 @@ public:
     }
 
     void on_destroy(void *);
-#if WLR_VERSION_MINOR > 16
     void on_start(void *);
     void on_ready(void *);
-#endif
 
     static QHash<void*, QWXWaylandServer*> map;
     QW_DECLARE_PUBLIC(QWXWaylandServer)
@@ -61,7 +57,6 @@ void QWXWaylandServerPrivate::on_destroy(void *)
     delete q_func();
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWXWaylandServerPrivate::on_start(void *)
 {
     Q_EMIT q_func()->start();
@@ -71,7 +66,6 @@ void QWXWaylandServerPrivate::on_ready(void *)
 {
     Q_EMIT q_func()->ready();
 }
-#endif
 
 QWXWaylandServer::QWXWaylandServer(wlr_xwayland_server *handle, bool isOwner)
     : QObject(nullptr)

--- a/src/types/qwxwaylandserver.h
+++ b/src/types/qwxwaylandserver.h
@@ -30,10 +30,8 @@ public:
 
 Q_SIGNALS:
     void beforeDestroy(QWXWaylandServer *self);
-#if WLR_VERSION_MINOR > 16
     void start();
     void ready();
-#endif
 
 private:
     QWXWaylandServer(wlr_xwayland_server *handle, bool isOwner);

--- a/src/types/qwxwaylandsurface.cpp
+++ b/src/types/qwxwaylandsurface.cpp
@@ -37,11 +37,9 @@ public:
         sc.connect(&handle->events.request_maximize, this, &QWXWaylandSurfacePrivate::on_request_maximize);
         sc.connect(&handle->events.request_fullscreen, this, &QWXWaylandSurfacePrivate::on_request_fullscreen);
         sc.connect(&handle->events.request_activate, this, &QWXWaylandSurfacePrivate::on_request_activate);
-#if WLR_VERSION_MINOR > 16
         sc.connect(&handle->events.associate, this, &QWXWaylandSurfacePrivate::on_associate);
         sc.connect(&handle->events.dissociate, this, &QWXWaylandSurfacePrivate::on_dissociate);
         sc.connect(&handle->events.set_strut_partial, this, &QWXWaylandSurfacePrivate::on_set_strut_partial);
-#endif
         sc.connect(&handle->events.set_title, this, &QWXWaylandSurfacePrivate::on_set_title);
         sc.connect(&handle->events.set_class, this, &QWXWaylandSurfacePrivate::on_set_class);
         sc.connect(&handle->events.set_role, this, &QWXWaylandSurfacePrivate::on_set_role);
@@ -69,11 +67,9 @@ public:
     void on_request_maximize(void *);
     void on_request_fullscreen(void *);
     void on_request_activate(void *);
-#if WLR_VERSION_MINOR > 16
     void on_associate(void *);
     void on_dissociate(void *);
     void on_set_strut_partial(void *);
-#endif
     void on_set_title(void *);
     void on_set_class(void *);
     void on_set_role(void *);
@@ -142,7 +138,6 @@ void QWXWaylandSurfacePrivate::on_request_activate(void *)
     Q_EMIT q_func()->requestActivate();
 }
 
-#if WLR_VERSION_MINOR > 16
 void QWXWaylandSurfacePrivate::on_associate(void *)
 {
     Q_EMIT q_func()->associate();
@@ -157,7 +152,6 @@ void QWXWaylandSurfacePrivate::on_set_strut_partial(void *)
 {
     Q_EMIT q_func()->strutPartialChanged();
 }
-#endif
 
 void QWXWaylandSurfacePrivate::on_set_title(void *)
 {
@@ -258,12 +252,10 @@ void QWXWaylandSurface::close()
     wlr_xwayland_surface_close(handle());
 }
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
 void QWXWaylandSurface::setWithdrawn(bool withdrawn)
 {
     wlr_xwayland_surface_set_withdrawn(handle(), withdrawn);
 }
-#endif
 
 void QWXWaylandSurface::setMinimized(bool minimized)
 {
@@ -280,13 +272,11 @@ void QWXWaylandSurface::setFullscreen(bool fullscreen)
     wlr_xwayland_surface_set_fullscreen(handle(), fullscreen);
 }
 
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
 QWXWaylandSurface *QWXWaylandSurface::tryFromWlrSurface(QWSurface *surface)
 {
     auto handle = wlr_xwayland_surface_try_from_wlr_surface(surface->handle());
     return handle ? from(handle) : nullptr;
 }
-#endif
 
 void QWXWaylandSurface::ping()
 {

--- a/src/types/qwxwaylandsurface.h
+++ b/src/types/qwxwaylandsurface.h
@@ -30,18 +30,14 @@ class QW_EXPORT QWXWaylandSurface : public QObject, public QWObject
 public:
     static QWXWaylandSurface *get(wlr_xwayland_surface* handle);
     static QWXWaylandSurface* from(wlr_xwayland_surface* handle);
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
     static QWXWaylandSurface *tryFromWlrSurface(QWSurface *surface);
-#endif
 
     wlr_xwayland_surface* handle() const;
     void activate(bool activated);
     void restack(QWXWaylandSurface *sibling, xcb_stack_mode mode);
     void configure(const QRect &rect);
     void close();
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR > 16
     void setWithdrawn(bool withdrawn);
-#endif
     void setMinimized(bool minimized);
     void setMaximized(bool maximized);
     void setFullscreen(bool fullscreen);
@@ -69,11 +65,9 @@ Q_SIGNALS:
     void overrideRedirectChanged();
     void geometryChanged();
     void pingTimeout();
-#if WLR_VERSION_MINOR > 16
     void associate();
     void dissociate();
     void strutPartialChanged();
-#endif
 
 private:
     QWXWaylandSurface(wlr_xwayland_surface *handle);

--- a/src/util/qwsignalconnector.h
+++ b/src/util/qwsignalconnector.h
@@ -22,16 +22,19 @@ public:
     Listener *connect(wl_signal *signal, void *object, SlotFun1 slot);
     using SlotFun2 = void (*)(void *obj, void *signalData, void *data);
     Listener *connect(wl_signal *signal, void *object, SlotFun2 slot, void *data);
-    template <typename T>
-    inline Listener *connect(wl_signal *signal, T *object, void (T::*slot)()) {
+    template <typename T, typename TSlot>
+    inline Listener *connect(wl_signal *signal, T *object, void (TSlot::*slot)())
+        requires ( std::is_base_of_v<TSlot,T> ) {
         return connect(signal, object, reinterpret_cast<SlotFun0>(*(void**)(&slot)));
     }
-    template <typename T, typename T1>
-    inline Listener *connect(wl_signal *signal, T *object, void (T::*slot)(T1*)) {
+    template <typename T, typename T1, typename TSlot>
+    inline Listener *connect(wl_signal *signal, T *object, void (TSlot::*slot)(T1*))
+        requires ( std::is_base_of_v<TSlot,T> ) {
         return connect(signal, object, reinterpret_cast<SlotFun1>(*(void**)(&slot)));
     }
-    template <typename T, typename T1, typename T2, typename T3>
-    inline Listener *connect(wl_signal *signal, T *object, void (T::*slot)(T1*, T2*), T3 *data) {
+    template <typename T, typename T1, typename T2, typename T3, typename TSlot>
+    inline Listener *connect(wl_signal *signal, T *object, void (TSlot::*slot)(T1*, T2*), T3 *data)
+        requires ( std::is_base_of_v<TSlot,T> ) {
         return connect(signal, object, reinterpret_cast<SlotFun2>(*(void**)(&slot)), data);
     }
     void disconnect(Listener *l);


### PR DESCRIPTION
breaking changes: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3760

- backend: creation doesn't need wlr_display, so get eventloop from display
- input: 
  - pointer enums now uses libwayland's;
  - pointer has extra relative_direction arg, give default value for backward compatiblility;
  - `WLR_INPUT_DEVICE_TABLET_TOOL` renamed
- wlr presentation not needed for some funcs
- output: state explicitly managed
- render: old API deprecated, must use render pass now
- xdg-shell: seperate surface base / popup / toplevel 's events