### PR TITLE
Add QWWrapObject class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ set(TARGET qwlroots)
 set(CMAKE_NAME ${CMAKE_PROJECT_NAME})
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+add_compile_options(-Wall -Wextra -Werror=unused-variable -Werror=unused-parameter)
+
 find_package(Qt${QT_VERSION_MAJOR}
     COMPONENTS
     Core
@@ -220,6 +222,7 @@ set(HEADERS
 set(PRIVATE_HEADERS
     types/qwinputdevice_p.h
     types/qwkeyboard_p.h
+    private/qwglobal_p.h
 )
 
 ws_generate(

--- a/src/class_template.txt
+++ b/src/class_template.txt
@@ -11,7 +11,7 @@ struct wlr_ABC;
 QW_BEGIN_NAMESPACE
 
 class QWABCPrivate;
-class QW_EXPORT QWABC : public QObject, public QWObject
+class QW_EXPORT QWABC : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWABC)
@@ -23,9 +23,6 @@ public:
     static QWABC *get(wlr_ABC *handle);
     static QWABC *from(wlr_ABC *handle);
 
-Q_SIGNALS:
-    void beforeDestroy(QWABC *self);
-
 private:
     QWABC(wlr_ABC *handle, bool isOwner);
 };
@@ -36,7 +33,7 @@ QW_END_NAMESPACE
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwabc.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -46,57 +43,30 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWABCPrivate : public QWObjectPrivate
+class QWABCPrivate : public QWWrapObjectPrivate
 {
 public:
     QWABCPrivate(wlr_ABC *handle, bool isOwner, QWABC *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+                              toDestroyFunction(wlr_ABC_destroy))
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWABCPrivate::on_destroy);
-    }
-    ~QWABCPrivate() {
-        if (!m_handle)
-            return;
-        destroy();
-        if (isHandleOwner)
-            wlr_ABC_destroy(q_func()->handle());
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWABC*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWABC)
-    QWSignalConnector sc;
 };
-QHash<void*, QWABC*> QWABCPrivate::map;
-
-void QWABCPrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWABCPrivate::map;
 
 QWABC::QWABC(wlr_ABC *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWABCPrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWABCPrivate(handle, isOwner, this))
 {
 
 }
 
 QWABC *QWABC::get(wlr_ABC *handle)
 {
-    return QWABCPrivate::map.value(handle);
+    return static_cast<QWABC*>(QWABCPrivate::map.value(handle));
 }
 
 QWABC *QWABC::from(wlr_ABC *handle)

--- a/src/class_template.txt
+++ b/src/class_template.txt
@@ -47,16 +47,14 @@ class QWABCPrivate : public QWWrapObjectPrivate
 {
 public:
     QWABCPrivate(wlr_ABC *handle, bool isOwner, QWABC *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_ABC_destroy))
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWABC)
 };
-QHash<void*, QWWrapObject*> QWABCPrivate::map;
 
 QWABC::QWABC(wlr_ABC *handle, bool isOwner)
     : QWWrapObject(*new QWABCPrivate(handle, isOwner, this))

--- a/src/private/qwglobal_p.h
+++ b/src/private/qwglobal_p.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2024 JiDe Zhang <zhangjide@deepin.org>.
+// SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+
+#pragma once
+
+#include "qwglobal.h"
+#include "util/qwsignalconnector.h"
+
+QW_BEGIN_NAMESPACE
+
+class QWWrapObjectPrivate : public QWObjectPrivate
+{
+public:
+    explicit QWWrapObjectPrivate(void *handle, bool isOwner, QWWrapObject *qq,
+                                 QHash<void*, QWWrapObject*> *globalMap, wl_signal *destroy_signal = nullptr,
+                                 std::function<void(void*)> destroy_function = nullptr);
+
+    ~QWWrapObjectPrivate();
+
+    template <typename Func>
+    static inline typename std::enable_if<QtPrivate::FunctionPointer<Func>::ArgumentCount == 1, void(*)(void*)>::type
+    toDestroyFunction(Func fun) {
+        return reinterpret_cast<void(*)(void*)>(fun);
+    }
+
+protected:
+    void on_destroy(void *);
+    void destroy();
+
+    QWSignalConnector sc;
+    std::function<void(void*)> wlr_destroy_function;
+    QHash<void*, QWWrapObject*> *map;
+
+    QW_DECLARE_PUBLIC(QWWrapObject)
+};
+
+QW_END_NAMESPACE

--- a/src/private/qwglobal_p.h
+++ b/src/private/qwglobal_p.h
@@ -12,7 +12,7 @@ class QWWrapObjectPrivate : public QWObjectPrivate
 {
 public:
     explicit QWWrapObjectPrivate(void *handle, bool isOwner, QWWrapObject *qq,
-                                 QHash<void*, QWWrapObject*> *globalMap, wl_signal *destroy_signal = nullptr,
+                                 wl_signal *destroy_signal = nullptr,
                                  std::function<void(void*)> destroy_function = nullptr);
 
     ~QWWrapObjectPrivate();
@@ -29,7 +29,7 @@ protected:
 
     QWSignalConnector sc;
     std::function<void(void*)> wlr_destroy_function;
-    QHash<void*, QWWrapObject*> *map;
+    static QHash<void*, QWWrapObject*> map;
 
     QW_DECLARE_PUBLIC(QWWrapObject)
 };

--- a/src/qwbackend.cpp
+++ b/src/qwbackend.cpp
@@ -29,7 +29,7 @@ class QWBackendPrivate : public QWWrapObjectPrivate
 {
 public:
     QWBackendPrivate(wlr_backend *handle, bool isOwner, QWBackend *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map,
+        : QWWrapObjectPrivate(handle, isOwner, qq,
                               &handle->events.destroy,
                               toDestroyFunction(wlr_backend_destroy))
     {
@@ -42,10 +42,8 @@ public:
 
     static QWBackend *createBackend(wlr_backend *handle, bool isOwner, QObject *parent);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWBackend)
 };
-QHash<void*, QWWrapObject*> QWBackendPrivate::map;
 
 void QWBackendPrivate::on_new_input(wlr_input_device *device)
 {

--- a/src/qwbackend.h
+++ b/src/qwbackend.h
@@ -29,7 +29,7 @@ class QWDisplay;
 class QWOutput;
 class QWInputDevice;
 class QWBackendPrivate;
-class QW_EXPORT QWBackend : public QObject, public QWObject
+class QW_EXPORT QWBackend : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWBackend)
@@ -57,7 +57,6 @@ public Q_SLOTS:
     bool start();
 
 Q_SIGNALS:
-    void beforeDestroy(QWBackend *self);
     void newInput(QWInputDevice *device);
     void newOutput(QWOutput *output);
 

--- a/src/qwdisplay.cpp
+++ b/src/qwdisplay.cpp
@@ -15,7 +15,7 @@ class QWDisplayPrivate : public QWWrapObjectPrivate
 {
 public:
     QWDisplayPrivate(wl_display *handle, bool isOwner, QWDisplay *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, nullptr, nullptr,
+        : QWWrapObjectPrivate(handle, isOwner, qq, nullptr,
                               toDestroyFunction(wl_display_destroy))
     {
 

--- a/src/qwdisplay.cpp
+++ b/src/qwdisplay.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QAbstractEventDispatcher>
 #include <QSocketNotifier>
@@ -11,34 +11,29 @@
 
 QW_BEGIN_NAMESPACE
 
-class QWDisplayPrivate : public QWObjectPrivate
+class QWDisplayPrivate : public QWWrapObjectPrivate
 {
 public:
     QWDisplayPrivate(wl_display *handle, bool isOwner, QWDisplay *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, nullptr, nullptr,
+                              toDestroyFunction(wl_display_destroy))
     {
 
     }
     ~QWDisplayPrivate() {
-        Q_EMIT q_func()->beforeDestroy(q_func());
-
-        sc.invalidate();
         Q_ASSERT(isHandleOwner);
         if (m_handle) {
             auto display = q_func()->handle();
             wl_display_destroy_clients(display);
-            wl_display_destroy(display);
         }
     }
 
     QW_DECLARE_PUBLIC(QWDisplay)
-    QWSignalConnector sc;
     wl_event_loop *loop = nullptr;
 };
 
 QWDisplay::QWDisplay(QObject *parent)
-    : QObject(parent)
-    , QWObject(*new QWDisplayPrivate(wl_display_create(), true, this))
+    : QWWrapObject(*new QWDisplayPrivate(wl_display_create(), true, this), parent)
 {
 
 }

--- a/src/qwdisplay.h
+++ b/src/qwdisplay.h
@@ -16,7 +16,7 @@ QT_END_NAMESPACE
 QW_BEGIN_NAMESPACE
 
 class QWDisplayPrivate;
-class QW_EXPORT QWDisplay : public QObject, public QWObject
+class QW_EXPORT QWDisplay : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWDisplay)
@@ -35,9 +35,6 @@ public:
     void start(QThread *thread);
 
     wl_event_loop *eventLoop() const;
-
-Q_SIGNALS:
-    void beforeDestroy(QWDisplay *self);
 
 public Q_SLOTS:
     void terminate();

--- a/src/qwglobal.cpp
+++ b/src/qwglobal.cpp
@@ -42,17 +42,16 @@ void QWObject::setData(void *owner, void *data)
     m_data = std::make_pair(owner, data);
 }
 
+QHash<void*, QWWrapObject*> QWWrapObjectPrivate::map;
 QWWrapObjectPrivate::QWWrapObjectPrivate(void *handle, bool isOwner, QWWrapObject *qq,
-                                         QHash<void *, QWWrapObject *> *globalMap, wl_signal *destroy_signal,
+                                         wl_signal *destroy_signal,
                                          std::function<void (void *)> destroy_function)
     : QWObjectPrivate(handle, isOwner, qq)
     , wlr_destroy_function(destroy_function)
-    , map(globalMap)
 {
-    if (map) {
-        Q_ASSERT(!map->contains(handle));
-        map->insert(handle, qq);
-    }
+    Q_ASSERT(!map.contains(handle));
+    map.insert(handle, qq);
+
     if (destroy_signal)
         sc.connect(destroy_signal, this, &QWWrapObjectPrivate::on_destroy);
 }
@@ -79,10 +78,10 @@ void QWWrapObjectPrivate::destroy()
 {
     Q_ASSERT(m_handle);
     Q_EMIT q_func()->beforeDestroy();
-    if (map) {
-        Q_ASSERT(map->contains(m_handle));
-        map->remove(m_handle);
-    }
+
+    Q_ASSERT(map.contains(m_handle));
+    map.remove(m_handle);
+
     sc.invalidate();
 }
 

--- a/src/qwglobal.cpp
+++ b/src/qwglobal.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwglobal.h"
+#include "private/qwglobal_p.h"
+
+#include <QHash>
 
 QW_BEGIN_NAMESPACE
 
@@ -37,6 +40,64 @@ void QWObject::setData(void *owner, void *data)
     }
 
     m_data = std::make_pair(owner, data);
+}
+
+QWWrapObjectPrivate::QWWrapObjectPrivate(void *handle, bool isOwner, QWWrapObject *qq,
+                                         QHash<void *, QWWrapObject *> *globalMap, wl_signal *destroy_signal,
+                                         std::function<void (void *)> destroy_function)
+    : QWObjectPrivate(handle, isOwner, qq)
+    , wlr_destroy_function(destroy_function)
+    , map(globalMap)
+{
+    if (map) {
+        Q_ASSERT(!map->contains(handle));
+        map->insert(handle, qq);
+    }
+    if (destroy_signal)
+        sc.connect(destroy_signal, this, &QWWrapObjectPrivate::on_destroy);
+}
+
+QWWrapObjectPrivate::~QWWrapObjectPrivate()
+{
+    if (m_handle && isHandleOwner) {
+        if (wlr_destroy_function)
+            wlr_destroy_function(m_handle);
+        else
+            qFatal("QWWrapObject(%p) can't to destroy, maybe its ownership is wl_display.",
+                   static_cast<void*>(q_func()));
+    }
+}
+
+void QWWrapObjectPrivate::on_destroy(void *)
+{
+    destroy();
+    m_handle = nullptr;
+    delete q_func();
+}
+
+void QWWrapObjectPrivate::destroy()
+{
+    Q_ASSERT(m_handle);
+    Q_EMIT q_func()->beforeDestroy();
+    if (map) {
+        Q_ASSERT(map->contains(m_handle));
+        map->remove(m_handle);
+    }
+    sc.invalidate();
+}
+
+QWWrapObject::QWWrapObject(QWWrapObjectPrivate &dd, QObject *parent)
+    : QObject(parent)
+    , QWObject(dd)
+{
+
+}
+
+QWWrapObject::~QWWrapObject()
+{
+    Q_D(QWWrapObject);
+    if (d->m_handle)
+        d->destroy();
 }
 
 QW_END_NAMESPACE

--- a/src/qwglobal.h
+++ b/src/qwglobal.h
@@ -43,6 +43,7 @@
 #endif
 
 #include <QScopedPointer>
+#include <QObject>
 
 QW_BEGIN_NAMESPACE
 
@@ -98,6 +99,21 @@ protected:
 
 private:
     std::pair<void*, void*> m_data; // <owner, data>
+};
+
+class QWWrapObjectPrivate;
+class QW_EXPORT QWWrapObject : public QObject, public QWObject
+{
+    Q_OBJECT
+
+Q_SIGNALS:
+    void beforeDestroy();
+
+protected:
+    QWWrapObject(QWWrapObjectPrivate &dd, QObject *parent = nullptr);
+    ~QWWrapObject();
+
+    QW_DECLARE_PRIVATE(QWWrapObject)
 };
 
 QW_END_NAMESPACE

--- a/src/render/qwallocator.cpp
+++ b/src/render/qwallocator.cpp
@@ -19,16 +19,14 @@ class QWAllocatorPrivate : public QWWrapObjectPrivate
 {
 public:
     QWAllocatorPrivate(wlr_allocator *handle, bool isOwner, QWAllocator *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_allocator_destroy))
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWAllocator)
 };
-QHash<void*, QWWrapObject*> QWAllocatorPrivate::map;
 
 QWAllocator::QWAllocator(wlr_allocator *handle, bool isOwner)
     : QWWrapObject(*new QWAllocatorPrivate(handle, isOwner, this))

--- a/src/render/qwallocator.h
+++ b/src/render/qwallocator.h
@@ -16,7 +16,7 @@ class QWBuffer;
 class QWBackend;
 class QWRenderer;
 class QWAllocatorPrivate;
-class QW_EXPORT QWAllocator : public QObject, public QWObject
+class QW_EXPORT QWAllocator : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWAllocator)
@@ -30,9 +30,6 @@ public:
     static QWAllocator *from(wlr_allocator *handle);
 
     QWBuffer *createBuffer(int width, int height, const wlr_drm_format *format);
-
-Q_SIGNALS:
-    void beforeDestroy(QWAllocator *self);
 
 private:
     QWAllocator(wlr_allocator *handle, bool isOwner);

--- a/src/render/qwrenderer.cpp
+++ b/src/render/qwrenderer.cpp
@@ -30,7 +30,7 @@ class QWRendererPrivate : public QWWrapObjectPrivate
 {
 public:
     QWRendererPrivate(wlr_renderer *handle, bool isOwner, QWRenderer *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_renderer_destroy))
     {
         sc.connect(&handle->events.lost, this, &QWRendererPrivate::on_lost);
@@ -38,10 +38,8 @@ public:
 
     void on_lost(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWRenderer)
 };
-QHash<void*, QWWrapObject*> QWRendererPrivate::map;
 
 void QWRendererPrivate::on_lost(void *)
 {

--- a/src/render/qwrenderer.h
+++ b/src/render/qwrenderer.h
@@ -23,7 +23,7 @@ class QWBackend;
 class QWBuffer;
 class QWTexture;
 class QWRendererPrivate;
-class QW_EXPORT QWRenderer : public QObject, public QWObject
+class QW_EXPORT QWRenderer : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWRenderer)
@@ -81,7 +81,6 @@ public:
 
 
 Q_SIGNALS:
-    void beforeDestroy(QWRenderer *self);
     void lost();
 
 private:

--- a/src/types/qwbuffer.cpp
+++ b/src/types/qwbuffer.cpp
@@ -17,7 +17,7 @@ class QWBufferPrivate : public QWWrapObjectPrivate
 {
 public:
     QWBufferPrivate(wlr_buffer *handle, bool isOwner, QWBuffer *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_buffer_drop))
     {
         sc.connect(&handle->events.release, this, &QWBufferPrivate::on_release);
@@ -25,10 +25,8 @@ public:
 
     void on_release(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWBuffer)
 };
-QHash<void*, QWWrapObject*> QWBufferPrivate::map;
 
 void QWBufferPrivate::on_release(void *)
 {

--- a/src/types/qwbuffer.h
+++ b/src/types/qwbuffer.h
@@ -23,7 +23,7 @@ QW_BEGIN_NAMESPACE
 
 class QWRenderer;
 class QWBufferPrivate;
-class QW_EXPORT QWBuffer : public QObject, public QWObject
+class QW_EXPORT QWBuffer : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWBuffer)
@@ -63,7 +63,6 @@ public:
     void endDataPtrAccess();
 
 Q_SIGNALS:
-    void beforeDestroy(QWBuffer *self);
     void release();
 
 private:

--- a/src/types/qwcompositor.cpp
+++ b/src/types/qwcompositor.cpp
@@ -28,17 +28,15 @@ class QWCompositorPrivate : public QWWrapObjectPrivate
 {
 public:
     QWCompositorPrivate(wlr_compositor *handle, bool isOwner, QWCompositor *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_surface, this, &QWCompositorPrivate::on_new_surface);
     }
 
     void on_new_surface(void *data);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWCompositor)
 };
-QHash<void*, QWWrapObject*> QWCompositorPrivate::map;
 
 void QWCompositorPrivate::on_new_surface(void *data)
 {
@@ -78,7 +76,7 @@ class QWSurfacePrivate : public QWWrapObjectPrivate
 {
 public:
     QWSurfacePrivate(wlr_surface *handle, bool isOwner, QWSurface *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.client_commit, this, &QWSurfacePrivate::on_client_commit);
         sc.connect(&handle->events.commit, this, &QWSurfacePrivate::on_commit);
@@ -97,10 +95,8 @@ public:
     void on_map(void *);
     void on_unmap(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSurface)
 };
-QHash<void*, QWWrapObject*> QWSurfacePrivate::map;
 
 void QWSurfacePrivate::on_client_commit(void *)
 {

--- a/src/types/qwcompositor.cpp
+++ b/src/types/qwcompositor.cpp
@@ -6,8 +6,8 @@
 #include "qwdisplay.h"
 #include "qwtexture.h"
 #include "qwoutput.h"
-#include "util/qwsignalconnector.h"
 #include "render/qwrenderer.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 #include <QRectF>
@@ -24,47 +24,21 @@ static_assert(std::is_same_v<wl_output_transform_t, std::underlying_type_t<wl_ou
 
 QW_BEGIN_NAMESPACE
 
-class QWCompositorPrivate : public QWObjectPrivate
+class QWCompositorPrivate : public QWWrapObjectPrivate
 {
 public:
     QWCompositorPrivate(wlr_compositor *handle, bool isOwner, QWCompositor *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWCompositorPrivate::on_destroy);
         sc.connect(&handle->events.new_surface, this, &QWCompositorPrivate::on_new_surface);
     }
-    ~QWCompositorPrivate() {
-        if (!m_handle)
-            return;
-        destroy();
-        if (isHandleOwner)
-            qFatal("QWCompositor(%p) can't to destroy, its ownership is wl_display", q_func());
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_new_surface(void *data);
 
-    static QHash<void*, QWCompositor*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWCompositor)
-    QWSignalConnector sc;
 };
-QHash<void*, QWCompositor*> QWCompositorPrivate::map;
-
-void QWCompositorPrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWCompositorPrivate::map;
 
 void QWCompositorPrivate::on_new_surface(void *data)
 {
@@ -73,15 +47,14 @@ void QWCompositorPrivate::on_new_surface(void *data)
 }
 
 QWCompositor::QWCompositor(wlr_compositor *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWCompositorPrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWCompositorPrivate(handle, isOwner, this))
 {
 
 }
 
 QWCompositor *QWCompositor::get(wlr_compositor *handle)
 {
-    return QWCompositorPrivate::map.value(handle);
+    return static_cast<QWCompositor*>(QWCompositorPrivate::map.value(handle));
 }
 
 QWCompositor *QWCompositor::from(wlr_compositor *handle)
@@ -101,15 +74,12 @@ QWCompositor *QWCompositor::create(QWDisplay *display, QWRenderer *renderer, uin
 
 /// QWSurface
 
-class QWSurfacePrivate : public QWObjectPrivate
+class QWSurfacePrivate : public QWWrapObjectPrivate
 {
 public:
     QWSurfacePrivate(wlr_surface *handle, bool isOwner, QWSurface *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWSurfacePrivate::on_destroy);
         sc.connect(&handle->events.client_commit, this, &QWSurfacePrivate::on_client_commit);
         sc.connect(&handle->events.commit, this, &QWSurfacePrivate::on_commit);
         sc.connect(&handle->events.new_subsurface, this, &QWSurfacePrivate::on_new_subsurface);
@@ -119,21 +89,7 @@ public:
         sc.connect(&handle->events.map, this, &QWSurfacePrivate::on_map);
         sc.connect(&handle->events.unmap, this, &QWSurfacePrivate::on_unmap);
     }
-    ~QWSurfacePrivate() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_client_commit(void *);
     void on_commit(void *);
     void on_new_subsurface(void *);
@@ -141,18 +97,10 @@ public:
     void on_map(void *);
     void on_unmap(void *);
 
-    static QHash<void*, QWSurface*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSurface)
-    QWSignalConnector sc;
 };
-QHash<void*, QWSurface*> QWSurfacePrivate::map;
-
-void QWSurfacePrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWSurfacePrivate::map;
 
 void QWSurfacePrivate::on_client_commit(void *)
 {
@@ -187,15 +135,14 @@ void QWSurfacePrivate::on_unmap(void *)
 }
 
 QWSurface::QWSurface(wlr_surface *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWSurfacePrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWSurfacePrivate(handle, isOwner, this))
 {
 
 }
 
 QWSurface *QWSurface::get(wlr_surface *handle)
 {
-    return QWSurfacePrivate::map.value(handle);
+    return static_cast<QWSurface*>(QWSurfacePrivate::map.value(handle));
 }
 
 QWSurface *QWSurface::from(wlr_surface *handle)
@@ -220,7 +167,7 @@ void QWSurface::forEachSurface(wlr_surface_iterator_func_t iterator, void *userD
 
 QRectF QWSurface::getBufferSourceBox() const
 {
-    wlr_fbox wfbox = { 0 };
+    wlr_fbox wfbox = { 0, 0, 0, 0 };
     wlr_surface_get_buffer_source_box(handle(), &wfbox);
     return QRectF { wfbox.x, wfbox.y, wfbox.width, wfbox.height };
 }
@@ -232,7 +179,7 @@ void QWSurface::getEffectiveDamage(pixman_region32_t *damage) const
 
 QRect QWSurface::getExtends() const
 {
-    wlr_box wbox = { 0 };
+    wlr_box wbox = { 0, 0, 0, 0 };
     wlr_surface_get_extends(handle(), &wbox);
     return QRect { wbox.x, wbox.y, wbox.width, wbox.height };
 }

--- a/src/types/qwcompositor.h
+++ b/src/types/qwcompositor.h
@@ -26,7 +26,7 @@ class QWTexture;
 class QWOutput;
 class QWSurface;
 class QWCompositorPrivate;
-class QW_EXPORT QWCompositor : public QObject, public QWObject
+class QW_EXPORT QWCompositor : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWCompositor)
@@ -40,7 +40,6 @@ public:
     static QWCompositor *create(QWDisplay *display, QWRenderer *renderer, uint32_t version);
 
 Q_SIGNALS:
-    void beforeDestroy(QWCompositor *self);
     void newSurface(QWSurface *surface);
 
 private:
@@ -50,7 +49,7 @@ private:
 
 class QWSubsurface;
 class QWSurfacePrivate;
-class QW_EXPORT QWSurface : public QObject, public QWObject
+class QW_EXPORT QWSurface : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSurface)
@@ -84,7 +83,6 @@ public:
     void unmap();
 
 Q_SIGNALS:
-    void beforeDestroy(QWSurface *self);
     void clientCommit();
     void commit();
     void newSubsurface(QWSubsurface *surface);

--- a/src/types/qwcontenttypev1.cpp
+++ b/src/types/qwcontenttypev1.cpp
@@ -20,15 +20,13 @@ class QWContentTypeManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWContentTypeManagerV1Private(wlr_content_type_manager_v1 *handle, bool isOwner, QWContentTypeManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWContentTypeManagerV1)
 };
-QHash<void*, QWWrapObject*> QWContentTypeManagerV1Private::map;
 
 QWContentTypeManagerV1::QWContentTypeManagerV1(wlr_content_type_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWContentTypeManagerV1Private(handle, isOwner, this))

--- a/src/types/qwcontenttypev1.h
+++ b/src/types/qwcontenttypev1.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWSurface;
 class QWContentTypeManagerV1Private;
-class QW_EXPORT QWContentTypeManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWContentTypeManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWContentTypeManagerV1)
@@ -28,9 +28,6 @@ public:
     static QWContentTypeManagerV1 *create(QWDisplay *display, uint32_t version);
 
     wp_content_type_v1_type_t getSurfaceContentType(QWSurface *surface);
-
-Q_SIGNALS:
-    void beforeDestroy(QWContentTypeManagerV1 *self);
 
 private:
     QWContentTypeManagerV1(wlr_content_type_manager_v1 *handle, bool isOwner);

--- a/src/types/qwcursor.cpp
+++ b/src/types/qwcursor.cpp
@@ -28,7 +28,7 @@ class QWCursorPrivate : public QWWrapObjectPrivate
 {
 public:
     QWCursorPrivate(wlr_cursor *handle, bool isOwner, QWCursor *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, nullptr,
+        : QWWrapObjectPrivate(handle, isOwner, qq, nullptr,
                               toDestroyFunction(wlr_cursor_destroy))
     {
         sc.connect(&handle->events.motion, this, &QWCursorPrivate::on_motion);
@@ -78,10 +78,8 @@ public:
     void on_tablet_tool_tip(void *data);
     void on_tablet_tool_button(void *data);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWCursor)
 };
-QHash<void*, QWWrapObject*> QWCursorPrivate::map;
 
 void QWCursorPrivate::on_motion(void *data)
 {

--- a/src/types/qwcursor.h
+++ b/src/types/qwcursor.h
@@ -38,7 +38,7 @@ class QWOutput;
 class QWBuffer;
 class QWXCursorManager;
 
-class QW_EXPORT QWCursor : public QObject, public QWObject
+class QW_EXPORT QWCursor : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWCursor)
@@ -75,7 +75,6 @@ public:
     QPointF position() const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWCursor *self);
     void motion(wlr_pointer_motion_event *event);
     void motionAbsolute(wlr_pointer_motion_absolute_event *event);
     void button(wlr_pointer_button_event *event);

--- a/src/types/qwcursorshapev1.cpp
+++ b/src/types/qwcursorshapev1.cpp
@@ -17,17 +17,15 @@ class QWCursorShapeManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWCursorShapeManagerV1Private(wlr_cursor_shape_manager_v1 *handle, bool isOwner, QWCursorShapeManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.request_set_shape, this, &QWCursorShapeManagerV1Private::on_request_set_shape);
     }
 
     void on_request_set_shape(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWCursorShapeManagerV1)
 };
-QHash<void*, QWWrapObject*> QWCursorShapeManagerV1Private::map;
 
 void QWCursorShapeManagerV1Private::on_request_set_shape(void *data)
 {

--- a/src/types/qwcursorshapev1.h
+++ b/src/types/qwcursorshapev1.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWCursorShapeManagerV1Private;
 
-class QW_EXPORT QWCursorShapeManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWCursorShapeManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWCursorShapeManagerV1)
@@ -28,7 +28,6 @@ public:
     static QWCursorShapeManagerV1 *create(QWDisplay *display, uint32_t version);
 
 Q_SIGNALS:
-    void beforeDestroy(QWCursorShapeManagerV1 *self);
     void requestSetShape(wlr_cursor_shape_manager_v1_request_set_shape_event *event);
 
 private:

--- a/src/types/qwdatacontrolmanagerv1.cpp
+++ b/src/types/qwdatacontrolmanagerv1.cpp
@@ -17,17 +17,15 @@ class QWDataControlManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWDataControlManagerV1Private(wlr_data_control_manager_v1 *handle, bool isOwner, QWDataControlManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_device, this, &QWDataControlManagerV1Private::on_new_device);
     }
 
     void on_new_device(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWDataControlManagerV1)
 };
-QHash<void*, QWWrapObject*> QWDataControlManagerV1Private::map;
 
 void QWDataControlManagerV1Private::on_new_device(void *data)
 {

--- a/src/types/qwdatacontrolv1.h
+++ b/src/types/qwdatacontrolv1.h
@@ -26,7 +26,7 @@ public:
 };
 
 class QWDataControlManagerV1Private;
-class QW_EXPORT QWDataControlManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWDataControlManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWDataControlManagerV1)
@@ -40,7 +40,6 @@ public:
     static QWDataControlManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWDataControlManagerV1 *self);
     void newDevice(QWDataControlDeviceV1 *device);
 
 private:

--- a/src/types/qwdatadevice.cpp
+++ b/src/types/qwdatadevice.cpp
@@ -17,15 +17,13 @@ class QWDataDeviceManagerPrivate : public QWWrapObjectPrivate
 {
 public:
     QWDataDeviceManagerPrivate(wlr_data_device_manager *handle, bool isOwner, QWDataDeviceManager *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWDataDeviceManager)
 };
-QHash<void*, QWWrapObject*> QWDataDeviceManagerPrivate::map;
 
 QWDataDeviceManager::QWDataDeviceManager(wlr_data_device_manager *handle, bool isOwner)
     : QWWrapObject(*new QWDataDeviceManagerPrivate(handle, isOwner, this))

--- a/src/types/qwdatadevice.h
+++ b/src/types/qwdatadevice.h
@@ -38,7 +38,7 @@ public:
 };
 
 class QWDataDeviceManagerPrivate;
-class QW_EXPORT QWDataDeviceManager : public QObject, public QWObject
+class QW_EXPORT QWDataDeviceManager : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWDataDeviceManager)
@@ -51,16 +51,13 @@ public:
     static QWDataDeviceManager *from(wlr_data_device_manager *handle);
     static QWDataDeviceManager *create(QWDisplay *display);
 
-Q_SIGNALS:
-    void beforeDestroy(QWDataDeviceManager *self);
-
 private:
     QWDataDeviceManager(wlr_data_device_manager *handle, bool isOwner);
     ~QWDataDeviceManager() = default;
 };
 
 class QWDragPrivate;
-class QW_EXPORT QWDrag : public QObject, public QWObject
+class QW_EXPORT QWDrag : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWDrag)
@@ -76,7 +73,6 @@ Q_SIGNALS:
     void focus();
     void motion(wlr_drag_motion_event *event);
     void drop(wlr_drag_drop_event *event);
-    void beforeDestroy(QWDrag *self);
 
 private:
     QWDrag(wlr_drag *handle, bool isOwner);

--- a/src/types/qwdrag.cpp
+++ b/src/types/qwdrag.cpp
@@ -16,7 +16,7 @@ class QWDragPrivate : public QWWrapObjectPrivate
 {
 public:
     QWDragPrivate(wlr_drag *handle, bool isOwner, QWDrag *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.focus, this, &QWDragPrivate::on_focus);
         sc.connect(&handle->events.motion, this, &QWDragPrivate::on_motion);
@@ -27,10 +27,8 @@ public:
     void on_motion(void *);
     void on_drop(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWDrag)
 };
-QHash<void*, QWWrapObject*> QWDragPrivate::map;
 
 void QWDragPrivate::on_focus(void *)
 {

--- a/src/types/qwdrm.cpp
+++ b/src/types/qwdrm.cpp
@@ -19,15 +19,13 @@ class QWDrmPrivate : public QWWrapObjectPrivate
 {
 public:
     QWDrmPrivate(wlr_drm *handle, bool isOwner, QWDrm *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWDrm)
 };
-QHash<void*, QWWrapObject*> QWDrmPrivate::map;
 
 QWDrm::QWDrm(wlr_drm *handle, bool isOwner)
     : QWWrapObject(*new QWDrmPrivate(handle, isOwner, this))

--- a/src/types/qwdrm.h
+++ b/src/types/qwdrm.h
@@ -15,7 +15,7 @@ QW_BEGIN_NAMESPACE
 class QWDrmPrivate;
 class QWDisplay;
 class QWRenderer;
-class QW_EXPORT QWDrm : public QObject, public QWObject
+class QW_EXPORT QWDrm : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWDrm)
@@ -27,9 +27,6 @@ public:
     static QWDrm *get(wlr_drm *handle);
     static QWDrm *from(wlr_drm *handle);
     static QWDrm *create(QWDisplay *display, QWRenderer *render);
-
-Q_SIGNALS:
-    void beforeDestroy(QWDrm *self);
 
 private:
     QWDrm(wlr_drm *handle, bool isOwner);

--- a/src/types/qwdrmleasev1.h
+++ b/src/types/qwdrmleasev1.h
@@ -42,7 +42,7 @@ public:
 };
 
 class QWDrmLeaseV1ManagerPrivate;
-class QW_EXPORT QWDrmLeaseV1Manager : public QObject, public QWObject
+class QW_EXPORT QWDrmLeaseV1Manager : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWDrmLeaseV1Manager)
@@ -61,7 +61,6 @@ public:
     void withdrawOutput(QWOutput *output);
 
 Q_SIGNALS:
-    void beforeDestroy(QWDrmLeaseV1Manager *self);
     void request(QWDrmLeaseRequestV1 *request);
 };
 

--- a/src/types/qwdrmleasev1manager.cpp
+++ b/src/types/qwdrmleasev1manager.cpp
@@ -19,17 +19,15 @@ class QWDrmLeaseV1ManagerPrivate : public QWWrapObjectPrivate
 {
 public:
     QWDrmLeaseV1ManagerPrivate(wlr_drm_lease_v1_manager *handle, bool isOwner, QWDrmLeaseV1Manager *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
+        : QWWrapObjectPrivate(handle, isOwner, qq)
     {
         sc.connect(&handle->events.request, this, &QWDrmLeaseV1ManagerPrivate::on_request);
     }
 
     void on_request(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWDrmLeaseV1Manager)
 };
-QHash<void*, QWWrapObject*> QWDrmLeaseV1ManagerPrivate::map;
 
 void QWDrmLeaseV1ManagerPrivate::on_request(void *data)
 {

--- a/src/types/qwexportdmabufmanagerv1.cpp
+++ b/src/types/qwexportdmabufmanagerv1.cpp
@@ -3,7 +3,7 @@
 
 #include "qwexportdmabufv1.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -13,55 +13,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWExportDmabufManagerV1Private : public QWObjectPrivate
+class QWExportDmabufManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWExportDmabufManagerV1Private(wlr_export_dmabuf_manager_v1 *handle, bool isOwner, QWExportDmabufManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWExportDmabufManagerV1Private::on_destroy);
-    }
-    ~QWExportDmabufManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWExportDmabufManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWExportDmabufManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWExportDmabufManagerV1*> QWExportDmabufManagerV1Private::map;
-
-void QWExportDmabufManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWExportDmabufManagerV1Private::map;
 
 QWExportDmabufManagerV1::QWExportDmabufManagerV1(wlr_export_dmabuf_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWExportDmabufManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWExportDmabufManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWExportDmabufManagerV1 *QWExportDmabufManagerV1::get(wlr_export_dmabuf_manager_v1 *handle)
 {
-    return QWExportDmabufManagerV1Private::map.value(handle);
+    return static_cast<QWExportDmabufManagerV1*>(QWExportDmabufManagerV1Private::map.value(handle));
 }
 
 QWExportDmabufManagerV1 *QWExportDmabufManagerV1::from(wlr_export_dmabuf_manager_v1 *handle)

--- a/src/types/qwexportdmabufmanagerv1.cpp
+++ b/src/types/qwexportdmabufmanagerv1.cpp
@@ -17,15 +17,13 @@ class QWExportDmabufManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWExportDmabufManagerV1Private(wlr_export_dmabuf_manager_v1 *handle, bool isOwner, QWExportDmabufManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWExportDmabufManagerV1)
 };
-QHash<void*, QWWrapObject*> QWExportDmabufManagerV1Private::map;
 
 QWExportDmabufManagerV1::QWExportDmabufManagerV1(wlr_export_dmabuf_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWExportDmabufManagerV1Private(handle, isOwner, this))

--- a/src/types/qwexportdmabufv1.h
+++ b/src/types/qwexportdmabufv1.h
@@ -12,7 +12,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWExportDmabufManagerV1Private;
-class QW_EXPORT QWExportDmabufManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWExportDmabufManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWExportDmabufManagerV1)
@@ -24,9 +24,6 @@ public:
     static QWExportDmabufManagerV1 *get(wlr_export_dmabuf_manager_v1 *handle);
     static QWExportDmabufManagerV1 *from(wlr_export_dmabuf_manager_v1 *handle);
     static QWExportDmabufManagerV1 *create(QWDisplay *display);
-
-Q_SIGNALS:
-    void beforeDestroy(QWExportDmabufManagerV1 *self);
 
 private:
     QWExportDmabufManagerV1(wlr_export_dmabuf_manager_v1 *handle, bool isOwner);

--- a/src/types/qwforeigntoplevelhandlev1.cpp
+++ b/src/types/qwforeigntoplevelhandlev1.cpp
@@ -20,7 +20,7 @@ class QWForeignToplevelHandleV1Private : public QWWrapObjectPrivate
 {
 public:
     QWForeignToplevelHandleV1Private(wlr_foreign_toplevel_handle_v1 *handle, bool isOwner, QWForeignToplevelHandleV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_foreign_toplevel_handle_v1_destroy))
     {
         sc.connect(&handle->events.request_maximize, this, &QWForeignToplevelHandleV1Private::on_request_maximize);
@@ -38,10 +38,8 @@ public:
     void on_request_close(void *);
     void on_set_rectangle(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWForeignToplevelHandleV1)
 };
-QHash<void*, QWWrapObject*> QWForeignToplevelHandleV1Private::map;
 
 void QWForeignToplevelHandleV1Private::on_request_maximize(void *data)
 {

--- a/src/types/qwforeigntoplevelhandlev1.h
+++ b/src/types/qwforeigntoplevelhandlev1.h
@@ -19,7 +19,7 @@ QW_BEGIN_NAMESPACE
 class QWOutput;
 class QWDisplay;
 class QWForeignToplevelManagerV1Private;
-class QW_EXPORT QWForeignToplevelManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWForeignToplevelManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWForeignToplevelManagerV1)
@@ -32,16 +32,13 @@ public:
     static QWForeignToplevelManagerV1 *from(wlr_foreign_toplevel_manager_v1 *handle);
     static QWForeignToplevelManagerV1 *create(QWDisplay *display);
 
-Q_SIGNALS:
-    void beforeDestroy(QWForeignToplevelManagerV1 *self);
-
 private:
     QWForeignToplevelManagerV1(wlr_foreign_toplevel_manager_v1 *handle, bool isOwner);
     ~QWForeignToplevelManagerV1() = default;
 };
 
 class QWForeignToplevelHandleV1Private;
-class QW_EXPORT QWForeignToplevelHandleV1 : public QObject, public QWObject
+class QW_EXPORT QWForeignToplevelHandleV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWForeignToplevelHandleV1)
@@ -67,7 +64,6 @@ public:
     void setTitle(const char *title);
 
 Q_SIGNALS:
-    void beforeDestroy(QWForeignToplevelHandleV1 *self);
     void requestMaximize(wlr_foreign_toplevel_handle_v1_maximized_event *event);
     void requestMinimize(wlr_foreign_toplevel_handle_v1_minimized_event *event);
     void requestActivate(wlr_foreign_toplevel_handle_v1_activated_event *event);

--- a/src/types/qwforeigntoplevelmanagerv1.cpp
+++ b/src/types/qwforeigntoplevelmanagerv1.cpp
@@ -20,15 +20,13 @@ class QWForeignToplevelManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWForeignToplevelManagerV1Private(wlr_foreign_toplevel_manager_v1 *handle, bool isOwner, QWForeignToplevelManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWForeignToplevelManagerV1)
 };
-QHash<void*, QWWrapObject*> QWForeignToplevelManagerV1Private::map;
 
 QWForeignToplevelManagerV1::QWForeignToplevelManagerV1(wlr_foreign_toplevel_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWForeignToplevelManagerV1Private(handle, isOwner, this))

--- a/src/types/qwforeigntoplevelmanagerv1.cpp
+++ b/src/types/qwforeigntoplevelmanagerv1.cpp
@@ -3,7 +3,7 @@
 
 #include "qwforeigntoplevelhandlev1.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -16,55 +16,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWForeignToplevelManagerV1Private : public QWObjectPrivate
+class QWForeignToplevelManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWForeignToplevelManagerV1Private(wlr_foreign_toplevel_manager_v1 *handle, bool isOwner, QWForeignToplevelManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWForeignToplevelManagerV1Private::on_destroy);
-    }
-    ~QWForeignToplevelManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWForeignToplevelManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWForeignToplevelManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWForeignToplevelManagerV1*> QWForeignToplevelManagerV1Private::map;
-
-void QWForeignToplevelManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWForeignToplevelManagerV1Private::map;
 
 QWForeignToplevelManagerV1::QWForeignToplevelManagerV1(wlr_foreign_toplevel_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWForeignToplevelManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWForeignToplevelManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWForeignToplevelManagerV1 *QWForeignToplevelManagerV1::get(wlr_foreign_toplevel_manager_v1 *handle)
 {
-    return QWForeignToplevelManagerV1Private::map.value(handle);
+    return static_cast<QWForeignToplevelManagerV1*>(QWForeignToplevelManagerV1Private::map.value(handle));
 }
 
 QWForeignToplevelManagerV1 *QWForeignToplevelManagerV1::from(wlr_foreign_toplevel_manager_v1 *handle)

--- a/src/types/qwfractionalscalemanagerv1.cpp
+++ b/src/types/qwfractionalscalemanagerv1.cpp
@@ -18,15 +18,13 @@ class QWFractionalScaleManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWFractionalScaleManagerV1Private(wlr_fractional_scale_manager_v1 *handle, bool isOwner, QWFractionalScaleManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWFractionalScaleManagerV1)
 };
-QHash<void*, QWWrapObject*> QWFractionalScaleManagerV1Private::map;
 
 QWFractionalScaleManagerV1::QWFractionalScaleManagerV1(wlr_fractional_scale_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWFractionalScaleManagerV1Private(handle, isOwner, this))

--- a/src/types/qwfractionalscalemanagerv1.cpp
+++ b/src/types/qwfractionalscalemanagerv1.cpp
@@ -4,7 +4,7 @@
 #include "qwfractionalscalemanagerv1.h"
 #include "qwdisplay.h"
 #include "qwcompositor.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -14,55 +14,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWFractionalScaleManagerV1Private : public QWObjectPrivate
+class QWFractionalScaleManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWFractionalScaleManagerV1Private(wlr_fractional_scale_manager_v1 *handle, bool isOwner, QWFractionalScaleManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWFractionalScaleManagerV1Private::on_destroy);
-    }
-    ~QWFractionalScaleManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWFractionalScaleManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWFractionalScaleManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWFractionalScaleManagerV1*> QWFractionalScaleManagerV1Private::map;
-
-void QWFractionalScaleManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWFractionalScaleManagerV1Private::map;
 
 QWFractionalScaleManagerV1::QWFractionalScaleManagerV1(wlr_fractional_scale_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWFractionalScaleManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWFractionalScaleManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWFractionalScaleManagerV1 *QWFractionalScaleManagerV1::get(wlr_fractional_scale_manager_v1 *handle)
 {
-    return QWFractionalScaleManagerV1Private::map.value(handle);
+    return static_cast<QWFractionalScaleManagerV1*>(QWFractionalScaleManagerV1Private::map.value(handle));
 }
 
 QWFractionalScaleManagerV1 *QWFractionalScaleManagerV1::from(wlr_fractional_scale_manager_v1 *handle)

--- a/src/types/qwfractionalscalemanagerv1.h
+++ b/src/types/qwfractionalscalemanagerv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWSurface;
 class QWFractionalScaleManagerV1Private;
-class QW_EXPORT QWFractionalScaleManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWFractionalScaleManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWFractionalScaleManagerV1)
@@ -27,9 +27,6 @@ public:
     static QWFractionalScaleManagerV1 *create(QWDisplay *display, uint32_t version);
 
     static void notifyScale(QWSurface *surface, double scale);
-
-Q_SIGNALS:
-    void beforeDestroy(QWFractionalScaleManagerV1 *self);
 
 private:
     QWFractionalScaleManagerV1(wlr_fractional_scale_manager_v1 *handle, bool isOwner);

--- a/src/types/qwfullscreenshellv1.cpp
+++ b/src/types/qwfullscreenshellv1.cpp
@@ -17,17 +17,15 @@ class QWFullScreenShellV1Private : public QWWrapObjectPrivate
 {
 public:
     QWFullScreenShellV1Private(wlr_fullscreen_shell_v1 *handle, bool isOwner, QWFullScreenShellV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.present_surface, this, &QWFullScreenShellV1Private::on_present_surface);
     }
 
     void on_present_surface(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWFullScreenShellV1)
 };
-QHash<void*, QWWrapObject*> QWFullScreenShellV1Private::map;
 
 void QWFullScreenShellV1Private::on_present_surface(void *data)
 {

--- a/src/types/qwfullscreenshellv1.h
+++ b/src/types/qwfullscreenshellv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWFullScreenShellV1Private;
-class QW_EXPORT QWFullScreenShellV1: public QObject, public QWObject
+class QW_EXPORT QWFullScreenShellV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWFullScreenShellV1)
@@ -27,7 +27,6 @@ public:
     static QWFullScreenShellV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWFullScreenShellV1 *self);
     void presentSurface(wlr_fullscreen_shell_v1_present_surface_event *event);
 
 private:

--- a/src/types/qwgammacontorlv1.cpp
+++ b/src/types/qwgammacontorlv1.cpp
@@ -17,17 +17,15 @@ class QWGammaControlManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWGammaControlManagerV1Private(wlr_gamma_control_manager_v1 *handle, bool isOwner, QWGammaControlManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.set_gamma, this, &QWGammaControlManagerV1Private::on_set_gamma);
     }
 
     void on_set_gamma(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWGammaControlManagerV1)
 };
-QHash<void*, QWWrapObject*> QWGammaControlManagerV1Private::map;
 
 void QWGammaControlManagerV1Private::on_set_gamma(void *data)
 {

--- a/src/types/qwgammacontorlv1.h
+++ b/src/types/qwgammacontorlv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWGammaControlManagerV1Private;
-class QW_EXPORT QWGammaControlManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWGammaControlManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWGammaControlManagerV1)
@@ -27,7 +27,6 @@ public:
     static QWGammaControlManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWGammaControlManagerV1 *self);
     void gammaChanged(wlr_gamma_control_manager_v1_set_gamma_event *event);
 
 private:

--- a/src/types/qwidle.cpp
+++ b/src/types/qwidle.cpp
@@ -19,17 +19,15 @@ class QWIdlePrivate : public QWWrapObjectPrivate
 {
 public:
     QWIdlePrivate(wlr_idle *handle, bool isOwner, QWIdle *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events->destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events->destroy)
     {
         sc.connect(&handle->events.activity_notify, this, &QWIdlePrivate::on_activity_notify);
     }
 
     void on_activity_notify(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWIdle)
 };
-QHash<void*, QWWrapObject*> QWIdlePrivate::map;
 
 void QWIdlePrivate::on_activity_notify(void *)
 {
@@ -77,7 +75,7 @@ class QWIdleTimeoutPrivate : public QWWrapObjectPrivate
 {
 public:
     QWIdleTimeoutPrivate(wlr_idle_timeout *handle, bool isOwner, QWIdleTimeout *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_idle_timeout_destroy))
     {
         sc.connect(&handle->events.idle, this, &QWIdleTimeoutPrivate::on_idle);
@@ -87,10 +85,8 @@ public:
     void on_idle(void *);
     void on_resume(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWIdleTimeout)
 };
-QHash<void*, QWWrapObject*> QWIdleTimeoutPrivate::map;
 
 void QWIdleTimeoutPrivate::on_idle(void *)
 {

--- a/src/types/qwidle.h
+++ b/src/types/qwidle.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 class QWSeat;
 class QWDisplay;
 class QWIdlePrivate;
-class QW_EXPORT QWIdle : public QObject, public QWObject
+class QW_EXPORT QWIdle : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWIdle)
@@ -30,7 +30,6 @@ public:
     void setEnabled(QWSeat *seat, bool enabled);
 
 Q_SIGNALS:
-    void beforeDestroy(QWIdle *self);
     void activityNotify();
 
 private:
@@ -39,7 +38,7 @@ private:
 };
 
 class QWIdleTimeoutPrivate;
-class QW_EXPORT QWIdleTimeout : public QObject, public QWObject
+class QW_EXPORT QWIdleTimeout : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWIdleTimeout)
@@ -55,7 +54,6 @@ public:
     static QWIdleTimeout *create(QWIdle *idle, QWSeat *seat, uint32_t timeout);
 
 Q_SIGNALS:
-    void beforeDestroy(QWIdleTimeout *self);
     void idle();
     void resume();
 

--- a/src/types/qwidleinhibitv1.cpp
+++ b/src/types/qwidleinhibitv1.cpp
@@ -3,7 +3,7 @@
 
 #include "qwidleinhibitv1.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -15,46 +15,21 @@ QW_BEGIN_NAMESPACE
 
 /// QWIdleInhibitManagerV1
 
-class QWIdleInhibitManagerV1Private : public QWObjectPrivate
+class QWIdleInhibitManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWIdleInhibitManagerV1Private(wlr_idle_inhibit_manager_v1 *handle, bool isOwner, QWIdleInhibitManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWIdleInhibitManagerV1Private::on_destroy);
         sc.connect(&handle->events.new_inhibitor, this, &QWIdleInhibitManagerV1Private::on_new_inhibitor);
     }
-    ~QWIdleInhibitManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_new_inhibitor(void *);
 
-    static QHash<void*, QWIdleInhibitManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWIdleInhibitManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWIdleInhibitManagerV1*> QWIdleInhibitManagerV1Private::map;
-
-void QWIdleInhibitManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWIdleInhibitManagerV1Private::map;
 
 void QWIdleInhibitManagerV1Private::on_new_inhibitor(void *data)
 {
@@ -63,15 +38,14 @@ void QWIdleInhibitManagerV1Private::on_new_inhibitor(void *data)
 }
 
 QWIdleInhibitManagerV1::QWIdleInhibitManagerV1(wlr_idle_inhibit_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWIdleInhibitManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWIdleInhibitManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWIdleInhibitManagerV1 *QWIdleInhibitManagerV1::get(wlr_idle_inhibit_manager_v1 *handle)
 {
-    return QWIdleInhibitManagerV1Private::map.value(handle);
+    return static_cast<QWIdleInhibitManagerV1*>(QWIdleInhibitManagerV1Private::map.value(handle));
 }
 
 QWIdleInhibitManagerV1 *QWIdleInhibitManagerV1::from(wlr_idle_inhibit_manager_v1 *handle)
@@ -91,56 +65,30 @@ QWIdleInhibitManagerV1 *QWIdleInhibitManagerV1::create(QWDisplay *display)
 
 /// QWIdleInhibitManagerV1
 
-class QWIdleInhibitorV1Private : public QWObjectPrivate
+class QWIdleInhibitorV1Private : public QWWrapObjectPrivate
 {
 public:
     QWIdleInhibitorV1Private(wlr_idle_inhibitor_v1 *handle, bool isOwner, QWIdleInhibitorV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWIdleInhibitorV1Private::on_destroy);
-    }
-    ~QWIdleInhibitorV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
     }
-
-    void on_destroy(void *);
     void on_new_inhibitor(void *);
 
-    static QHash<void*, QWIdleInhibitorV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWIdleInhibitorV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWIdleInhibitorV1*> QWIdleInhibitorV1Private::map;
-
-void QWIdleInhibitorV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWIdleInhibitorV1Private::map;
 
 QWIdleInhibitorV1::QWIdleInhibitorV1(wlr_idle_inhibitor_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWIdleInhibitorV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWIdleInhibitorV1Private(handle, isOwner, this))
 {
 
 }
 
 QWIdleInhibitorV1 *QWIdleInhibitorV1::get(wlr_idle_inhibitor_v1 *handle)
 {
-    return QWIdleInhibitorV1Private::map.value(handle);
+    return static_cast<QWIdleInhibitorV1*>(QWIdleInhibitorV1Private::map.value(handle));
 }
 
 QWIdleInhibitorV1 *QWIdleInhibitorV1::from(wlr_idle_inhibitor_v1 *handle)

--- a/src/types/qwidleinhibitv1.cpp
+++ b/src/types/qwidleinhibitv1.cpp
@@ -19,17 +19,15 @@ class QWIdleInhibitManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWIdleInhibitManagerV1Private(wlr_idle_inhibit_manager_v1 *handle, bool isOwner, QWIdleInhibitManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_inhibitor, this, &QWIdleInhibitManagerV1Private::on_new_inhibitor);
     }
 
     void on_new_inhibitor(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWIdleInhibitManagerV1)
 };
-QHash<void*, QWWrapObject*> QWIdleInhibitManagerV1Private::map;
 
 void QWIdleInhibitManagerV1Private::on_new_inhibitor(void *data)
 {
@@ -69,16 +67,14 @@ class QWIdleInhibitorV1Private : public QWWrapObjectPrivate
 {
 public:
     QWIdleInhibitorV1Private(wlr_idle_inhibitor_v1 *handle, bool isOwner, QWIdleInhibitorV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
     void on_new_inhibitor(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWIdleInhibitorV1)
 };
-QHash<void*, QWWrapObject*> QWIdleInhibitorV1Private::map;
 
 QWIdleInhibitorV1::QWIdleInhibitorV1(wlr_idle_inhibitor_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWIdleInhibitorV1Private(handle, isOwner, this))

--- a/src/types/qwidleinhibitv1.h
+++ b/src/types/qwidleinhibitv1.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWIdleInhibitorV1;
 class QWIdleInhibitManagerV1Private;
-class QW_EXPORT QWIdleInhibitManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWIdleInhibitManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWIdleInhibitManagerV1)
@@ -28,7 +28,6 @@ public:
     static QWIdleInhibitManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWIdleInhibitManagerV1 *self);
     void newInhibitor(QWIdleInhibitorV1 *inhibitor);
 
 private:
@@ -37,7 +36,7 @@ private:
 };
 
 class QWIdleInhibitorV1Private;
-class QW_EXPORT QWIdleInhibitorV1 : public QObject, public QWObject
+class QW_EXPORT QWIdleInhibitorV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWIdleInhibitorV1)
@@ -48,9 +47,6 @@ public:
 
     static QWIdleInhibitorV1 *get(wlr_idle_inhibitor_v1 *handle);
     static QWIdleInhibitorV1 *from(wlr_idle_inhibitor_v1 *handle);
-
-Q_SIGNALS:
-    void beforeDestroy(QWIdleInhibitorV1 *self);
 
 private:
     QWIdleInhibitorV1(wlr_idle_inhibitor_v1 *handle, bool isOwner);

--- a/src/types/qwinputdevice.cpp
+++ b/src/types/qwinputdevice.cpp
@@ -17,12 +17,11 @@ extern "C" {
 QW_BEGIN_NAMESPACE
 
 QWInputDevicePrivate::QWInputDevicePrivate(wlr_input_device *handle, bool isOwner, QWInputDevice *qq)
-    : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+    : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
 {
 
 }
 
-QHash<void*, QWWrapObject*> QWInputDevicePrivate::map;
 
 QWInputDevice::QWInputDevice(QWInputDevicePrivate &dd)
     : QWWrapObject(dd)

--- a/src/types/qwinputdevice.cpp
+++ b/src/types/qwinputdevice.cpp
@@ -17,54 +17,28 @@ extern "C" {
 QW_BEGIN_NAMESPACE
 
 QWInputDevicePrivate::QWInputDevicePrivate(wlr_input_device *handle, bool isOwner, QWInputDevice *qq)
-    : QWObjectPrivate(handle, isOwner, qq)
+    : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
 {
-    Q_ASSERT(!map.contains(handle));
-    map.insert(handle, qq);
-    sc.connect(&handle->events.destroy, this, &QWInputDevicePrivate::on_destroy);
+
 }
 
-QWInputDevicePrivate::~QWInputDevicePrivate()
-{
-    if (!m_handle)
-        return;
-    destroy();
-}
+QHash<void*, QWWrapObject*> QWInputDevicePrivate::map;
 
-void QWInputDevicePrivate::destroy() {
-    Q_ASSERT(m_handle);
-    Q_ASSERT(map.contains(m_handle));
-    Q_EMIT q_func()->beforeDestroy(q_func());
-    map.remove(m_handle);
-    sc.invalidate();
-}
-
-void QWInputDevicePrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
-
-QHash<void*, QWInputDevice*> QWInputDevicePrivate::map;
-
-QWInputDevice::QWInputDevice(QWObjectPrivate &dd)
-    : QObject(nullptr)
-    , QWObject(dd)
+QWInputDevice::QWInputDevice(QWInputDevicePrivate &dd)
+    : QWWrapObject(dd)
 {
 
 }
 
 QWInputDevice::QWInputDevice(wlr_input_device *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWInputDevicePrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWInputDevicePrivate(handle, isOwner, this))
 {
 
 }
 
 QWInputDevice *QWInputDevice::get(wlr_input_device *handle)
 {
-    return QWInputDevicePrivate::map.value(handle);
+    return static_cast<QWInputDevice*>(QWInputDevicePrivate::map.value(handle));
 }
 
 QWInputDevice *QWInputDevice::from(wlr_input_device *handle)

--- a/src/types/qwinputdevice.h
+++ b/src/types/qwinputdevice.h
@@ -11,7 +11,7 @@ struct wlr_input_device;
 QW_BEGIN_NAMESPACE
 
 class QWInputDevicePrivate;
-class QW_EXPORT QWInputDevice : public QObject, public QWObject
+class QW_EXPORT QWInputDevice : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputDevice)
@@ -23,11 +23,8 @@ public:
     static QWInputDevice *get(wlr_input_device *handle);
     static QWInputDevice *from(wlr_input_device *handle);
 
-Q_SIGNALS:
-    void beforeDestroy(QWInputDevice *self);
-
 protected:
-    QWInputDevice(QWObjectPrivate &dd);
+    QWInputDevice(QWInputDevicePrivate &dd);
     virtual ~QWInputDevice() override = default;
 private:
     QWInputDevice(wlr_input_device *handle, bool isOwner);

--- a/src/types/qwinputdevice_p.h
+++ b/src/types/qwinputdevice_p.h
@@ -22,7 +22,6 @@ class QWInputDevicePrivate : public QWWrapObjectPrivate
 public:
     QWInputDevicePrivate(wlr_input_device *handle, bool isOwner, QWInputDevice *qq);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputDevice)
 };
 

--- a/src/types/qwinputdevice_p.h
+++ b/src/types/qwinputdevice_p.h
@@ -6,7 +6,7 @@
 // WARNING: This file is not part of the QWlroots API.
 
 #include "qwglobal.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QObject>
 #include <QHash>
@@ -17,18 +17,13 @@ QW_BEGIN_NAMESPACE
 
 class QWInputDevice;
 
-class QWInputDevicePrivate : public QWObjectPrivate
+class QWInputDevicePrivate : public QWWrapObjectPrivate
 {
 public:
     QWInputDevicePrivate(wlr_input_device *handle, bool isOwner, QWInputDevice *qq);
-    virtual ~QWInputDevicePrivate() override;
 
-    inline void destroy();
-    void on_destroy(void *);
-
-    static QHash<void*, QWInputDevice*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputDevice)
-    QWSignalConnector sc;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwinputinhibitmanager.cpp
+++ b/src/types/qwinputinhibitmanager.cpp
@@ -18,7 +18,7 @@ class QWInputInhibitManagerPrivate : public QWWrapObjectPrivate
 {
 public:
     QWInputInhibitManagerPrivate(wlr_input_inhibit_manager *handle, bool isOwner, QWInputInhibitManager *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.activate, this, &QWInputInhibitManagerPrivate::on_activate);
         sc.connect(&handle->events.deactivate, this, &QWInputInhibitManagerPrivate::on_deactivate);
@@ -27,10 +27,8 @@ public:
     void on_activate(void *);
     void on_deactivate(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputInhibitManager)
 };
-QHash<void*, QWWrapObject*> QWInputInhibitManagerPrivate::map;
 
 void QWInputInhibitManagerPrivate::on_activate(void *)
 {

--- a/src/types/qwinputinhibitmanager.h
+++ b/src/types/qwinputinhibitmanager.h
@@ -12,7 +12,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWInputInhibitManagerPrivate;
-class QW_EXPORT QWInputInhibitManager : public QObject, public QWObject
+class QW_EXPORT QWInputInhibitManager : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputInhibitManager)
@@ -26,7 +26,6 @@ public:
     static QWInputInhibitManager *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWInputInhibitManager *self);
     void activate();
     void deactivate();
 

--- a/src/types/qwinputmethodkeyboardgrabv2.cpp
+++ b/src/types/qwinputmethodkeyboardgrabv2.cpp
@@ -19,16 +19,14 @@ class QWInputMethodKeyboardGrabV2Private : public QWWrapObjectPrivate
 {
 public:
     QWInputMethodKeyboardGrabV2Private(wlr_input_method_keyboard_grab_v2 *handle, bool isOwner, QWInputMethodKeyboardGrabV2 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_input_method_keyboard_grab_v2_destroy))
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputMethodKeyboardGrabV2)
 };
-QHash<void*, QWWrapObject*> QWInputMethodKeyboardGrabV2Private::map;
 
 QWInputMethodKeyboardGrabV2::QWInputMethodKeyboardGrabV2(wlr_input_method_keyboard_grab_v2 *handle, bool isOwner)
     : QWWrapObject(*new QWInputMethodKeyboardGrabV2Private(handle, isOwner, this))

--- a/src/types/qwinputmethodmanagerv2.cpp
+++ b/src/types/qwinputmethodmanagerv2.cpp
@@ -3,7 +3,7 @@
 
 #include "qwinputmethodv2.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -15,46 +15,21 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWInputMethodManagerV2Private : public QWObjectPrivate
+class QWInputMethodManagerV2Private : public QWWrapObjectPrivate
 {
 public:
     QWInputMethodManagerV2Private(wlr_input_method_manager_v2 *handle, bool isOwner, QWInputMethodManagerV2 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWInputMethodManagerV2Private::on_destroy);
         sc.connect(&handle->events.input_method, this, &QWInputMethodManagerV2Private::on_input_method);
     }
-    ~QWInputMethodManagerV2Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_input_method(void *);
 
-    static QHash<void*, QWInputMethodManagerV2*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputMethodManagerV2)
-    QWSignalConnector sc;
 };
-QHash<void*, QWInputMethodManagerV2*> QWInputMethodManagerV2Private::map;
-
-void QWInputMethodManagerV2Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWInputMethodManagerV2Private::map;
 
 void QWInputMethodManagerV2Private::on_input_method(void *data)
 {
@@ -63,15 +38,14 @@ void QWInputMethodManagerV2Private::on_input_method(void *data)
 }
 
 QWInputMethodManagerV2::QWInputMethodManagerV2(wlr_input_method_manager_v2 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWInputMethodManagerV2Private(handle, isOwner, this))
+    : QWWrapObject(*new QWInputMethodManagerV2Private(handle, isOwner, this))
 {
 
 }
 
 QWInputMethodManagerV2 *QWInputMethodManagerV2::get(wlr_input_method_manager_v2 *handle)
 {
-    return QWInputMethodManagerV2Private::map.value(handle);
+    return static_cast<QWInputMethodManagerV2*>(QWInputMethodManagerV2Private::map.value(handle));
 }
 
 QWInputMethodManagerV2 *QWInputMethodManagerV2::from(wlr_input_method_manager_v2 *handle)

--- a/src/types/qwinputmethodmanagerv2.cpp
+++ b/src/types/qwinputmethodmanagerv2.cpp
@@ -19,17 +19,15 @@ class QWInputMethodManagerV2Private : public QWWrapObjectPrivate
 {
 public:
     QWInputMethodManagerV2Private(wlr_input_method_manager_v2 *handle, bool isOwner, QWInputMethodManagerV2 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.input_method, this, &QWInputMethodManagerV2Private::on_input_method);
     }
 
     void on_input_method(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputMethodManagerV2)
 };
-QHash<void*, QWWrapObject*> QWInputMethodManagerV2Private::map;
 
 void QWInputMethodManagerV2Private::on_input_method(void *data)
 {

--- a/src/types/qwinputmethodv2.cpp
+++ b/src/types/qwinputmethodv2.cpp
@@ -18,7 +18,7 @@ class QWInputMethodV2Private : public QWWrapObjectPrivate
 {
 public:
     QWInputMethodV2Private(wlr_input_method_v2 *handle, bool isOwner, QWInputMethodV2 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.commit, this, &QWInputMethodV2Private::on_commit);
         sc.connect(&handle->events.new_popup_surface, this, &QWInputMethodV2Private::on_new_popup_surface);
@@ -29,10 +29,8 @@ public:
     void on_new_popup_surface(void *);
     void on_grab_keyboard(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputMethodV2)
 };
-QHash<void*, QWWrapObject*> QWInputMethodV2Private::map;
 
 void QWInputMethodV2Private::on_commit(void *data)
 {

--- a/src/types/qwinputmethodv2.h
+++ b/src/types/qwinputmethodv2.h
@@ -19,7 +19,7 @@ class QWSurface;
 class QWDisplay;
 class QWInputMethodV2;
 class QWInputMethodManagerV2Private;
-class QW_EXPORT QWInputMethodManagerV2 : public QObject, public QWObject
+class QW_EXPORT QWInputMethodManagerV2 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputMethodManagerV2)
@@ -33,7 +33,6 @@ public:
     static QWInputMethodManagerV2 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWInputMethodManagerV2 *self);
     void inputMethod(QWInputMethodV2 *input_method);
 
 private:
@@ -43,7 +42,7 @@ private:
 
 
 class QWInputMethodKeyboardGrabV2Private;
-class QW_EXPORT QWInputMethodKeyboardGrabV2 : public QObject, public QWObject
+class QW_EXPORT QWInputMethodKeyboardGrabV2 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputMethodKeyboardGrabV2)
@@ -61,15 +60,12 @@ public:
     void sendModifiers(wlr_keyboard_modifiers *modifiers);
     void setKeyboard(QWKeyboard *keyboard);
 
-Q_SIGNALS:
-    void beforeDestroy(QWInputMethodKeyboardGrabV2 *self);
-
 private:
     QWInputMethodKeyboardGrabV2(wlr_input_method_keyboard_grab_v2 *handle, bool isOwner);
 };
 
 class QWInputPopupSurfaceV2Private;
-class QW_EXPORT QWInputPopupSurfaceV2 : public QObject, public QWObject
+class QW_EXPORT QWInputPopupSurfaceV2 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputPopupSurfaceV2)
@@ -86,16 +82,13 @@ public:
 
     void send_text_input_rectangle(const QRect &sbox);
 
-Q_SIGNALS:
-    void beforeDestroy(QWInputPopupSurfaceV2 *self);
-
 private:
     QWInputPopupSurfaceV2(wlr_input_popup_surface_v2 *handle, bool isOwner);
     ~QWInputPopupSurfaceV2() = default;
 };
 
 class QWInputMethodV2Private;
-class QW_EXPORT QWInputMethodV2 : public QObject, public QWObject
+class QW_EXPORT QWInputMethodV2 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWInputMethodV2)
@@ -116,7 +109,6 @@ public:
     void sendUnavailable();
 
 Q_SIGNALS:
-    void beforeDestroy(QWInputMethodV2 *self);
     void commit(QWInputMethodV2 *inputMethod);
     void newPopupSurface(QWInputPopupSurfaceV2 *surface);
     void grabKeybord(QWInputMethodKeyboardGrabV2 *keyboardGrab);

--- a/src/types/qwinputpopupsurfacev2.cpp
+++ b/src/types/qwinputpopupsurfacev2.cpp
@@ -3,7 +3,7 @@
 
 #include "qwinputmethodv2.h"
 #include "qwcompositor.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 #include <QRect>
@@ -17,55 +17,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWInputPopupSurfaceV2Private : public QWObjectPrivate
+class QWInputPopupSurfaceV2Private : public QWWrapObjectPrivate
 {
 public:
     QWInputPopupSurfaceV2Private(wlr_input_popup_surface_v2 *handle, bool isOwner, QWInputPopupSurfaceV2 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWInputPopupSurfaceV2Private::on_destroy);
-    }
-    ~QWInputPopupSurfaceV2Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWInputPopupSurfaceV2*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputPopupSurfaceV2)
-    QWSignalConnector sc;
 };
-QHash<void*, QWInputPopupSurfaceV2*> QWInputPopupSurfaceV2Private::map;
-
-void QWInputPopupSurfaceV2Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWInputPopupSurfaceV2Private::map;
 
 QWInputPopupSurfaceV2::QWInputPopupSurfaceV2(wlr_input_popup_surface_v2 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWInputPopupSurfaceV2Private(handle, isOwner, this))
+    : QWWrapObject(*new QWInputPopupSurfaceV2Private(handle, isOwner, this))
 {
 
 }
 
 QWInputPopupSurfaceV2 *QWInputPopupSurfaceV2::get(wlr_input_popup_surface_v2 *handle)
 {
-    return QWInputPopupSurfaceV2Private::map.value(handle);
+    return static_cast<QWInputPopupSurfaceV2*>(QWInputPopupSurfaceV2Private::map.value(handle));
 }
 
 QWInputPopupSurfaceV2 *QWInputPopupSurfaceV2::from(wlr_input_popup_surface_v2 *handle)

--- a/src/types/qwinputpopupsurfacev2.cpp
+++ b/src/types/qwinputpopupsurfacev2.cpp
@@ -21,15 +21,13 @@ class QWInputPopupSurfaceV2Private : public QWWrapObjectPrivate
 {
 public:
     QWInputPopupSurfaceV2Private(wlr_input_popup_surface_v2 *handle, bool isOwner, QWInputPopupSurfaceV2 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWInputPopupSurfaceV2)
 };
-QHash<void*, QWWrapObject*> QWInputPopupSurfaceV2Private::map;
 
 QWInputPopupSurfaceV2::QWInputPopupSurfaceV2(wlr_input_popup_surface_v2 *handle, bool isOwner)
     : QWWrapObject(*new QWInputPopupSurfaceV2Private(handle, isOwner, this))

--- a/src/types/qwkeyboardgroup.cpp
+++ b/src/types/qwkeyboardgroup.cpp
@@ -17,7 +17,7 @@ class QWKeyboardGroupPrivate : public QWWrapObjectPrivate
 {
 public:
     QWKeyboardGroupPrivate(wlr_keyboard_group *handle, bool isOwner, QWKeyboardGroup *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, nullptr,
+        : QWWrapObjectPrivate(handle, isOwner, qq, nullptr,
                               toDestroyFunction(wlr_keyboard_group_destroy))
     {
         sc.connect(&handle->events.enter, this, &QWKeyboardGroupPrivate::on_enter);
@@ -27,10 +27,8 @@ public:
     void on_enter(void *);
     void on_leave(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWKeyboardGroup)
 };
-QHash<void*, QWWrapObject*> QWKeyboardGroupPrivate::map;
 
 void QWKeyboardGroupPrivate::on_enter(void *data)
 {

--- a/src/types/qwkeyboardgroup.h
+++ b/src/types/qwkeyboardgroup.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWKeyboard;
 class QWKeyboardGroupPrivate;
-class QW_EXPORT QWKeyboardGroup : public QObject, public QWObject
+class QW_EXPORT QWKeyboardGroup : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWKeyboardGroup)
@@ -32,7 +32,6 @@ public:
     void removeKeyboard(QWKeyboard *keyboard);
 
 Q_SIGNALS:
-    void beforeDestroy(QWKeyboardGroup *self);
     void enter(wl_array *keycodes);
     void leave(wl_array *keycodes);
 

--- a/src/types/qwkeyboardshortcutsinhibitmanagerv1.cpp
+++ b/src/types/qwkeyboardshortcutsinhibitmanagerv1.cpp
@@ -17,17 +17,15 @@ class QWKeyboardShortcutsInhibitManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWKeyboardShortcutsInhibitManagerV1Private(wlr_keyboard_shortcuts_inhibit_manager_v1 *handle, bool isOwner, QWKeyboardShortcutsInhibitManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_inhibitor, this, &QWKeyboardShortcutsInhibitManagerV1Private::on_new_inhibitor);
     }
 
     void on_new_inhibitor(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWKeyboardShortcutsInhibitManagerV1)
 };
-QHash<void*, QWWrapObject*> QWKeyboardShortcutsInhibitManagerV1Private::map;
 
 void QWKeyboardShortcutsInhibitManagerV1Private::on_new_inhibitor(void *data)
 {

--- a/src/types/qwkeyboardshortcutsinhibitv1.cpp
+++ b/src/types/qwkeyboardshortcutsinhibitv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwkeyboardshortcutsinhibitv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -12,55 +12,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWKeyboardShortcutsInhibitorV1Private : public QWObjectPrivate
+class QWKeyboardShortcutsInhibitorV1Private : public QWWrapObjectPrivate
 {
 public:
     QWKeyboardShortcutsInhibitorV1Private(wlr_keyboard_shortcuts_inhibitor_v1 *handle, bool isOwner, QWKeyboardShortcutsInhibitorV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWKeyboardShortcutsInhibitorV1Private::on_destroy);
-    }
-    ~QWKeyboardShortcutsInhibitorV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWKeyboardShortcutsInhibitorV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWKeyboardShortcutsInhibitorV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWKeyboardShortcutsInhibitorV1*> QWKeyboardShortcutsInhibitorV1Private::map;
-
-void QWKeyboardShortcutsInhibitorV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWKeyboardShortcutsInhibitorV1Private::map;
 
 QWKeyboardShortcutsInhibitorV1::QWKeyboardShortcutsInhibitorV1(wlr_keyboard_shortcuts_inhibitor_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWKeyboardShortcutsInhibitorV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWKeyboardShortcutsInhibitorV1Private(handle, isOwner, this))
 {
 
 }
 
 QWKeyboardShortcutsInhibitorV1 *QWKeyboardShortcutsInhibitorV1::get(wlr_keyboard_shortcuts_inhibitor_v1 *handle)
 {
-    return QWKeyboardShortcutsInhibitorV1Private::map.value(handle);
+    return static_cast<QWKeyboardShortcutsInhibitorV1*>(QWKeyboardShortcutsInhibitorV1Private::map.value(handle));
 }
 
 QWKeyboardShortcutsInhibitorV1 *QWKeyboardShortcutsInhibitorV1::from(wlr_keyboard_shortcuts_inhibitor_v1 *handle)

--- a/src/types/qwkeyboardshortcutsinhibitv1.cpp
+++ b/src/types/qwkeyboardshortcutsinhibitv1.cpp
@@ -16,15 +16,13 @@ class QWKeyboardShortcutsInhibitorV1Private : public QWWrapObjectPrivate
 {
 public:
     QWKeyboardShortcutsInhibitorV1Private(wlr_keyboard_shortcuts_inhibitor_v1 *handle, bool isOwner, QWKeyboardShortcutsInhibitorV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWKeyboardShortcutsInhibitorV1)
 };
-QHash<void*, QWWrapObject*> QWKeyboardShortcutsInhibitorV1Private::map;
 
 QWKeyboardShortcutsInhibitorV1::QWKeyboardShortcutsInhibitorV1(wlr_keyboard_shortcuts_inhibitor_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWKeyboardShortcutsInhibitorV1Private(handle, isOwner, this))

--- a/src/types/qwkeyboardshortcutsinhibitv1.h
+++ b/src/types/qwkeyboardshortcutsinhibitv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWKeyboardShortcutsInhibitorV1Private;
-class QW_EXPORT QWKeyboardShortcutsInhibitorV1 : public QObject, public QWObject
+class QW_EXPORT QWKeyboardShortcutsInhibitorV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWKeyboardShortcutsInhibitorV1)
@@ -28,16 +28,13 @@ public:
     void activate();
     void deactivate();
 
-Q_SIGNALS:
-    void beforeDestroy(QWKeyboardShortcutsInhibitorV1 *self);
-
 private:
     QWKeyboardShortcutsInhibitorV1(wlr_keyboard_shortcuts_inhibitor_v1 *handle, bool isOwner);
     ~QWKeyboardShortcutsInhibitorV1() = default;
 };
 
 class QWKeyboardShortcutsInhibitManagerV1Private;
-class QW_EXPORT QWKeyboardShortcutsInhibitManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWKeyboardShortcutsInhibitManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWKeyboardShortcutsInhibitManagerV1)
@@ -51,7 +48,6 @@ public:
     static QWKeyboardShortcutsInhibitManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWKeyboardShortcutsInhibitManagerV1 *self);
     void newInhibitor(QWKeyboardShortcutsInhibitorV1 *inhibitor);
 
 private:

--- a/src/types/qwlayershellv1.cpp
+++ b/src/types/qwlayershellv1.cpp
@@ -28,17 +28,15 @@ class QWLayerShellV1Private : public QWWrapObjectPrivate
 {
 public:
     QWLayerShellV1Private(wlr_layer_shell_v1 *handle, bool isOwner, QWLayerShellV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_surface, this, &QWLayerShellV1Private::on_new_surface);
     }
 
     void on_new_surface(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWLayerShellV1)
 };
-QHash<void*, QWWrapObject*> QWLayerShellV1Private::map;
 
 void QWLayerShellV1Private::on_new_surface(void *data)
 {
@@ -78,7 +76,7 @@ class QWLayerSurfaceV1Private : public QWWrapObjectPrivate
 {
 public:
     QWLayerSurfaceV1Private(wlr_layer_surface_v1 *handle, bool isOwner, QWLayerSurfaceV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_layer_surface_v1_destroy))
     {
         sc.connect(&handle->events.new_popup, this, &QWLayerSurfaceV1Private::on_new_popup);
@@ -86,10 +84,8 @@ public:
 
     void on_new_popup(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWLayerSurfaceV1)
 };
-QHash<void*, QWWrapObject*> QWLayerSurfaceV1Private::map;
 
 void QWLayerSurfaceV1Private::on_new_popup(void *data)
 {

--- a/src/types/qwlayershellv1.h
+++ b/src/types/qwlayershellv1.h
@@ -21,7 +21,7 @@ class QWSurface;
 class QWLayerSurfaceV1;
 class QWLayerShellV1Private;
 class QWXdgPopup;
-class QW_EXPORT QWLayerShellV1 : public QObject, public QWObject
+class QW_EXPORT QWLayerShellV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWLayerShellV1)
@@ -36,7 +36,6 @@ public:
 
 Q_SIGNALS:
     void newSurface(QWLayerSurfaceV1 *surface);
-    void beforeDestroy(QWLayerShellV1 *self);
 
 private:
     QWLayerShellV1(wlr_layer_shell_v1 *handle, bool isOwner);
@@ -44,7 +43,7 @@ private:
 };
 
 class QWLayerSurfaceV1Private;
-class QW_EXPORT QWLayerSurfaceV1 : public QObject, public QWObject
+class QW_EXPORT QWLayerSurfaceV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWLayerSurfaceV1)
@@ -68,7 +67,6 @@ public:
     QWSurface *surface() const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWLayerSurfaceV1 *self);
     void newPopup(QWXdgPopup *popup);
 
 private:

--- a/src/types/qwlinuxdmabufv1.cpp
+++ b/src/types/qwlinuxdmabufv1.cpp
@@ -18,15 +18,13 @@ class QWLinuxDmabufV1Private : public QWWrapObjectPrivate
 {
 public:
     QWLinuxDmabufV1Private(wlr_linux_dmabuf_v1 *handle, bool isOwner, QWLinuxDmabufV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWLinuxDmabufV1)
 };
-QHash<void*, QWWrapObject*> QWLinuxDmabufV1Private::map;
 
 QWLinuxDmabufV1::QWLinuxDmabufV1(wlr_linux_dmabuf_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWLinuxDmabufV1Private(handle, isOwner, this))

--- a/src/types/qwlinuxdmabufv1.cpp
+++ b/src/types/qwlinuxdmabufv1.cpp
@@ -4,7 +4,7 @@
 #include "qwlinuxdmabufv1.h"
 #include "qwdisplay.h"
 #include "qwrenderer.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -14,55 +14,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWLinuxDmabufV1Private : public QWObjectPrivate
+class QWLinuxDmabufV1Private : public QWWrapObjectPrivate
 {
 public:
     QWLinuxDmabufV1Private(wlr_linux_dmabuf_v1 *handle, bool isOwner, QWLinuxDmabufV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWLinuxDmabufV1Private::on_destroy);
-    }
-    ~QWLinuxDmabufV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWLinuxDmabufV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWLinuxDmabufV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWLinuxDmabufV1*> QWLinuxDmabufV1Private::map;
-
-void QWLinuxDmabufV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWLinuxDmabufV1Private::map;
 
 QWLinuxDmabufV1::QWLinuxDmabufV1(wlr_linux_dmabuf_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWLinuxDmabufV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWLinuxDmabufV1Private(handle, isOwner, this))
 {
 
 }
 
 QWLinuxDmabufV1 *QWLinuxDmabufV1::get(wlr_linux_dmabuf_v1 *handle)
 {
-    return QWLinuxDmabufV1Private::map.value(handle);
+    return static_cast<QWLinuxDmabufV1*>(QWLinuxDmabufV1Private::map.value(handle));
 }
 
 QWLinuxDmabufV1 *QWLinuxDmabufV1::from(wlr_linux_dmabuf_v1 *handle)

--- a/src/types/qwlinuxdmabufv1.h
+++ b/src/types/qwlinuxdmabufv1.h
@@ -29,7 +29,7 @@ public:
 };
 
 class QWLinuxDmabufV1Private;
-class QW_EXPORT QWLinuxDmabufV1 : public QObject, public QWObject
+class QW_EXPORT QWLinuxDmabufV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWLinuxDmabufV1)
@@ -42,9 +42,6 @@ public:
     static QWLinuxDmabufV1 *from(wlr_linux_dmabuf_v1 *handle);
     static QWLinuxDmabufV1 *create(QWDisplay *display, uint32_t version, const QWLinuxDmabufFeedbackV1 *defaultFeedback);
     static QWLinuxDmabufV1 *create(QWDisplay *display, uint32_t version, QWRenderer *renderer);
-
-Q_SIGNALS:
-    void beforeDestroy(QWLinuxDmabufV1 *self);
 
 private:
     QWLinuxDmabufV1(wlr_linux_dmabuf_v1 *handle, bool isOwner);

--- a/src/types/qwoutput.cpp
+++ b/src/types/qwoutput.cpp
@@ -27,7 +27,7 @@ class QWOutputPrivate : public QWWrapObjectPrivate
 {
 public:
     QWOutputPrivate(wlr_output *handle, bool isOwner, QWOutput *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_output_destroy))
     {
         sc.connect(&handle->events.frame, this, &QWOutputPrivate::on_frame);
@@ -51,10 +51,8 @@ public:
     void on_description(void *data);
     void on_request_state(void *data);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWOutput)
 };
-QHash<void*, QWWrapObject*> QWOutputPrivate::map;
 
 void QWOutputPrivate::on_frame(void *)
 {

--- a/src/types/qwoutput.h
+++ b/src/types/qwoutput.h
@@ -38,7 +38,7 @@ class QWRenderer;
 class QWBuffer;
 class QWOutputInterface;
 class QWOutputPrivate;
-class QW_EXPORT QWOutput : public QObject, public QWObject
+class QW_EXPORT QWOutput : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWOutput)
@@ -116,7 +116,6 @@ public:
     bool configurePrimarySwapchain(const wlr_output_state *state, wlr_swapchain **swapchain);
 
 Q_SIGNALS:
-    void beforeDestroy(QWOutput *self);
     void frame();
     void damage(wlr_output_event_damage *event);
     void needsFrame();

--- a/src/types/qwoutputlayout.cpp
+++ b/src/types/qwoutputlayout.cpp
@@ -26,7 +26,7 @@ class QWOutputLayoutPrivate : public QWWrapObjectPrivate
 {
 public:
     QWOutputLayoutPrivate(wlr_output_layout *handle, bool isOwner, QWOutputLayout *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_output_layout_destroy))
     {
         sc.connect(&handle->events.add, this, &QWOutputLayoutPrivate::on_add);
@@ -36,10 +36,8 @@ public:
     void on_add(void *data);
     void on_change(void *data);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWOutputLayout)
 };
-QHash<void*, QWWrapObject*> QWOutputLayoutPrivate::map;
 
 void QWOutputLayoutPrivate::on_add(void *data)
 {

--- a/src/types/qwoutputlayout.h
+++ b/src/types/qwoutputlayout.h
@@ -17,7 +17,7 @@ class QWDisplay;
 class QWOutput;
 class QWRenderer;
 class QWOutputLayoutPrivate;
-class QW_EXPORT QWOutputLayout : public QObject, public QWObject
+class QW_EXPORT QWOutputLayout : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWOutputLayout)
@@ -54,7 +54,6 @@ public:
     QRect getBox(QWOutput *reference) const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWOutputLayout *self);
     // TODO: make to QWOutputLayoutOutput
     void add(wlr_output_layout_output *output);
     void change(wlr_output_layout_output *output);

--- a/src/types/qwoutputmanagementv1.h
+++ b/src/types/qwoutputmanagementv1.h
@@ -44,7 +44,7 @@ public:
 };
 
 class QWOutputManagerV1Private;
-class QW_EXPORT QWOutputManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWOutputManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWOutputManagerV1)
@@ -60,7 +60,6 @@ public:
     void setConfiguration(QWOutputConfigurationV1 *config);
 
 Q_SIGNALS:
-    void beforeDestroy(QWOutputManagerV1 *self);
     void apply(QWOutputConfigurationV1 *config);
     void test(QWOutputConfigurationV1 *config);
 

--- a/src/types/qwoutputmanagerv1.cpp
+++ b/src/types/qwoutputmanagerv1.cpp
@@ -20,7 +20,7 @@ class QWOutputManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWOutputManagerV1Private(wlr_output_manager_v1 *handle, bool isOwner, QWOutputManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.apply, this, &QWOutputManagerV1Private::on_apply);
         sc.connect(&handle->events.test, this, &QWOutputManagerV1Private::on_test);
@@ -29,10 +29,8 @@ public:
     void on_apply(void *);
     void on_test(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWOutputManagerV1)
 };
-QHash<void*, QWWrapObject*> QWOutputManagerV1Private::map;
 
 void QWOutputManagerV1Private::on_apply(void *data)
 {

--- a/src/types/qwoutputpowermanagementv1.cpp
+++ b/src/types/qwoutputpowermanagementv1.cpp
@@ -17,17 +17,15 @@ class QWOutputPowerManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWOutputPowerManagerV1Private(wlr_output_power_manager_v1 *handle, bool isOwner, QWOutputPowerManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.set_mode, this, &QWOutputPowerManagerV1Private::on_set_mode);
     }
 
     void on_set_mode(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWOutputPowerManagerV1)
 };
-QHash<void*, QWWrapObject*> QWOutputPowerManagerV1Private::map;
 
 void QWOutputPowerManagerV1Private::on_set_mode(void *data)
 {

--- a/src/types/qwoutputpowermanagementv1.h
+++ b/src/types/qwoutputpowermanagementv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWOutputPowerManagerV1Private;
-class QW_EXPORT QWOutputPowerManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWOutputPowerManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWOutputPowerManagerV1)
@@ -27,7 +27,6 @@ public:
     static QWOutputPowerManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWOutputPowerManagerV1 *self);
     void modeChanged(wlr_output_power_v1_set_mode_event* event);
 
 private:

--- a/src/types/qwpointer.cpp
+++ b/src/types/qwpointer.cpp
@@ -3,7 +3,7 @@
 
 #include "qwpointer.h"
 #include "qwinputdevice_p.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 extern "C" {
 #include <wlr/types/wlr_pointer.h>

--- a/src/types/qwpointerconstraintsv1.cpp
+++ b/src/types/qwpointerconstraintsv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwpointerconstraintsv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <qwseat.h>
@@ -15,37 +15,21 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWPointerConstraintsV1Private : public QWObjectPrivate
+class QWPointerConstraintsV1Private : public QWWrapObjectPrivate
 {
 public:
     QWPointerConstraintsV1Private(wlr_pointer_constraints_v1 *handle, bool isOwner, QWPointerConstraintsV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
         sc.connect(&handle->events.new_constraint, this, &QWPointerConstraintsV1Private::new_constraint);
-    }
-    ~QWPointerConstraintsV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
-
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
     }
 
     void new_constraint(wlr_pointer_constraint_v1 *);
 
-    static QHash<void*, QWPointerConstraintsV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPointerConstraintsV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWPointerConstraintsV1*> QWPointerConstraintsV1Private::map;
+QHash<void*, QWWrapObject*> QWPointerConstraintsV1Private::map;
 
 void QWPointerConstraintsV1Private::new_constraint(wlr_pointer_constraint_v1 *constraint)
 {
@@ -53,15 +37,14 @@ void QWPointerConstraintsV1Private::new_constraint(wlr_pointer_constraint_v1 *co
 }
 
 QWPointerConstraintsV1::QWPointerConstraintsV1(wlr_pointer_constraints_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWPointerConstraintsV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWPointerConstraintsV1Private(handle, isOwner, this))
 {
 
 }
 
 QWPointerConstraintsV1 *QWPointerConstraintsV1::get(wlr_pointer_constraints_v1 *handle)
 {
-    return QWPointerConstraintsV1Private::map.value(handle);
+    return static_cast<QWPointerConstraintsV1*>(QWPointerConstraintsV1Private::map.value(handle));
 }
 
 QWPointerConstraintsV1 *QWPointerConstraintsV1::from(wlr_pointer_constraints_v1 *handle)

--- a/src/types/qwpointerconstraintsv1.cpp
+++ b/src/types/qwpointerconstraintsv1.cpp
@@ -19,17 +19,15 @@ class QWPointerConstraintsV1Private : public QWWrapObjectPrivate
 {
 public:
     QWPointerConstraintsV1Private(wlr_pointer_constraints_v1 *handle, bool isOwner, QWPointerConstraintsV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
+        : QWWrapObjectPrivate(handle, isOwner, qq)
     {
         sc.connect(&handle->events.new_constraint, this, &QWPointerConstraintsV1Private::new_constraint);
     }
 
     void new_constraint(wlr_pointer_constraint_v1 *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPointerConstraintsV1)
 };
-QHash<void*, QWWrapObject*> QWPointerConstraintsV1Private::map;
 
 void QWPointerConstraintsV1Private::new_constraint(wlr_pointer_constraint_v1 *constraint)
 {

--- a/src/types/qwpointerconstraintsv1.h
+++ b/src/types/qwpointerconstraintsv1.h
@@ -12,7 +12,7 @@ struct wlr_pointer_constraints_v1;
 QW_BEGIN_NAMESPACE
 
 class QWPointerConstraintV1Private;
-class QW_EXPORT QWPointerConstraintV1 : public QObject, public QWObject
+class QW_EXPORT QWPointerConstraintV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPointerConstraintV1)
@@ -30,7 +30,6 @@ public:
     void sendDeactivated();
 
 Q_SIGNALS:
-    void beforeDestroy(QWPointerConstraintV1 *self);
     void setRegion();
 
 private:
@@ -42,7 +41,7 @@ class QWSeat;
 class QWDisplay;
 class QWSurface;
 class QWPointerConstraintsV1Private;
-class QW_EXPORT QWPointerConstraintsV1 : public QObject, public QWObject
+class QW_EXPORT QWPointerConstraintsV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPointerConstraintsV1)
@@ -58,7 +57,6 @@ public:
     QWPointerConstraintV1* constraintForSurface(QWSurface *surface, QWSeat *seat);
 
 Q_SIGNALS:
-    void beforeDestroy(QWPointerConstraintsV1 *self);
     void newConstraint(QWPointerConstraintV1 *);
 
 private:

--- a/src/types/qwpointerconstraintv1.cpp
+++ b/src/types/qwpointerconstraintv1.cpp
@@ -16,17 +16,15 @@ class QWPointerConstraintV1Private : public QWWrapObjectPrivate
 {
 public:
     QWPointerConstraintV1Private(wlr_pointer_constraint_v1 *handle, bool isOwner, QWPointerConstraintV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.set_region, this, &QWPointerConstraintV1Private::on_set_region);
     }
 
     void on_set_region(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPointerConstraintV1)
 };
-QHash<void*, QWWrapObject*> QWPointerConstraintV1Private::map;
 
 void QWPointerConstraintV1Private::on_set_region(void *)
 {

--- a/src/types/qwpointergesturesv1.cpp
+++ b/src/types/qwpointergesturesv1.cpp
@@ -19,15 +19,13 @@ class QWPointerGesturesV1Private : public QWWrapObjectPrivate
 {
 public:
     QWPointerGesturesV1Private(wlr_pointer_gestures_v1 *handle, bool isOwner, QWPointerGesturesV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPointerGesturesV1)
 };
-QHash<void*, QWWrapObject*> QWPointerGesturesV1Private::map;
 
 QWPointerGesturesV1::QWPointerGesturesV1(wlr_pointer_gestures_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWPointerGesturesV1Private(handle, isOwner, this))

--- a/src/types/qwpointergesturesv1.cpp
+++ b/src/types/qwpointergesturesv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwpointergesturesv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwseat.h>
 #include <qwdisplay.h>
@@ -15,55 +15,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWPointerGesturesV1Private : public QWObjectPrivate
+class QWPointerGesturesV1Private : public QWWrapObjectPrivate
 {
 public:
     QWPointerGesturesV1Private(wlr_pointer_gestures_v1 *handle, bool isOwner, QWPointerGesturesV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWPointerGesturesV1Private::on_destroy);
-    }
-    ~QWPointerGesturesV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWPointerGesturesV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPointerGesturesV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWPointerGesturesV1*> QWPointerGesturesV1Private::map;
-
-void QWPointerGesturesV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWPointerGesturesV1Private::map;
 
 QWPointerGesturesV1::QWPointerGesturesV1(wlr_pointer_gestures_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWPointerGesturesV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWPointerGesturesV1Private(handle, isOwner, this))
 {
 
 }
 
 QWPointerGesturesV1 *QWPointerGesturesV1::get(wlr_pointer_gestures_v1 *handle)
 {
-    return QWPointerGesturesV1Private::map.value(handle);
+    return static_cast<QWPointerGesturesV1*>(QWPointerGesturesV1Private::map.value(handle));
 }
 
 QWPointerGesturesV1 *QWPointerGesturesV1::from(wlr_pointer_gestures_v1 *handle)

--- a/src/types/qwpointergesturesv1.h
+++ b/src/types/qwpointergesturesv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWSeat;
 class QWPointerGesturesV1Private;
-class QW_EXPORT QWPointerGesturesV1 : public QObject, public QWObject
+class QW_EXPORT QWPointerGesturesV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPointerGesturesV1)
@@ -34,9 +34,6 @@ public:
     void sendPinchEnd(QWSeat *seat, uint32_t time_msec,bool cancelled);
     void sendHoldBegin(QWSeat *seat, uint32_t time_msec, uint32_t fingers);
     void sendHoldEnd(QWSeat *seat, uint32_t time_msec, bool cancelled);
-
-Q_SIGNALS:
-    void beforeDestroy(QWPointerGesturesV1 *self);
 
 private:
     QWPointerGesturesV1(wlr_pointer_gestures_v1 *handle, bool isOwner);

--- a/src/types/qwpresentation.cpp
+++ b/src/types/qwpresentation.cpp
@@ -20,15 +20,13 @@ class QWPresentationPrivate : public QWWrapObjectPrivate
 {
 public:
     QWPresentationPrivate(wlr_presentation *handle, bool isOwner, QWPresentation *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPresentation)
 };
-QHash<void*, QWWrapObject*> QWPresentationPrivate::map;
 
 QWPresentation::QWPresentation(wlr_presentation *handle, bool isOwner)
     : QWWrapObject(*new QWPresentationPrivate(handle, isOwner, this))

--- a/src/types/qwpresentation.h
+++ b/src/types/qwpresentation.h
@@ -19,7 +19,7 @@ class QWDisplay;
 class QWBackend;
 class QWPresentationFeedback;
 class QWPresentationPrivate;
-class QW_EXPORT QWPresentation : public QObject, public QWObject
+class QW_EXPORT QWPresentation : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPresentation)
@@ -36,9 +36,6 @@ public:
 
     void surfaceTexturedOnOutput(QWSurface *surface, QWOutput *output);
     void surfaceScannedOutOnOutput(QWSurface *surface, QWOutput *output);
-
-Q_SIGNALS:
-    void beforeDestroy(QWPresentation *self);
 
 private:
     QWPresentation(wlr_presentation *handle, bool isOwner);

--- a/src/types/qwprimaryselection.cpp
+++ b/src/types/qwprimaryselection.cpp
@@ -17,15 +17,13 @@ class QWPrimarySelectionSourcePrivate : public QWWrapObjectPrivate
 {
 public:
     QWPrimarySelectionSourcePrivate(wlr_primary_selection_source *handle, bool isOwner, QWPrimarySelectionSource *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_primary_selection_source_destroy))
     {
 
     }
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPrimarySelectionSource)
 };
-QHash<void*, QWWrapObject*> QWPrimarySelectionSourcePrivate::map;
 
 QWPrimarySelectionSource::QWPrimarySelectionSource(wlr_primary_selection_source *handle, bool isOwner)
     : QWWrapObject(*new QWPrimarySelectionSourcePrivate(handle, isOwner, this))

--- a/src/types/qwprimaryselection.h
+++ b/src/types/qwprimaryselection.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 
 class QWSeat;
 class QWPrimarySelectionSourcePrivate;
-class QW_EXPORT QWPrimarySelectionSource : public QObject, public QWObject
+class QW_EXPORT QWPrimarySelectionSource : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPrimarySelectionSource)
@@ -32,9 +32,6 @@ public:
     void send(const char *mime_type, int fd);
     void requestSetPrimarySelection(QWSeat *seat, wlr_seat_client *client, uint32_t serial);
     void setPrimarySelection(QWSeat *seat, uint32_t serial);
-
-Q_SIGNALS:
-    void beforeDestroy(QWPrimarySelectionSource *self);
 
 private:
     QWPrimarySelectionSource(wlr_primary_selection_source *handle, bool isOwner);

--- a/src/types/qwprimaryselectionv1.cpp
+++ b/src/types/qwprimaryselectionv1.cpp
@@ -17,15 +17,13 @@ class QWPrimarySelectionV1DeviceManagerPrivate : public QWWrapObjectPrivate
 {
 public:
     QWPrimarySelectionV1DeviceManagerPrivate(wlr_primary_selection_v1_device_manager *handle, bool isOwner, QWPrimarySelectionV1DeviceManager *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPrimarySelectionV1DeviceManager)
 };
-QHash<void*, QWWrapObject*> QWPrimarySelectionV1DeviceManagerPrivate::map;
 
 QWPrimarySelectionV1DeviceManager::QWPrimarySelectionV1DeviceManager(wlr_primary_selection_v1_device_manager *handle, bool isOwner)
     : QWWrapObject(*new QWPrimarySelectionV1DeviceManagerPrivate(handle, isOwner, this))

--- a/src/types/qwprimaryselectionv1.cpp
+++ b/src/types/qwprimaryselectionv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwprimaryselectionv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <QHash>
@@ -13,55 +13,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWPrimarySelectionV1DeviceManagerPrivate : public QWObjectPrivate
+class QWPrimarySelectionV1DeviceManagerPrivate : public QWWrapObjectPrivate
 {
 public:
     QWPrimarySelectionV1DeviceManagerPrivate(wlr_primary_selection_v1_device_manager *handle, bool isOwner, QWPrimarySelectionV1DeviceManager *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWPrimarySelectionV1DeviceManagerPrivate::on_destroy);
-    }
-    ~QWPrimarySelectionV1DeviceManagerPrivate() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWPrimarySelectionV1DeviceManager*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWPrimarySelectionV1DeviceManager)
-    QWSignalConnector sc;
 };
-QHash<void*, QWPrimarySelectionV1DeviceManager*> QWPrimarySelectionV1DeviceManagerPrivate::map;
-
-void QWPrimarySelectionV1DeviceManagerPrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWPrimarySelectionV1DeviceManagerPrivate::map;
 
 QWPrimarySelectionV1DeviceManager::QWPrimarySelectionV1DeviceManager(wlr_primary_selection_v1_device_manager *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWPrimarySelectionV1DeviceManagerPrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWPrimarySelectionV1DeviceManagerPrivate(handle, isOwner, this))
 {
 
 }
 
 QWPrimarySelectionV1DeviceManager *QWPrimarySelectionV1DeviceManager::get(wlr_primary_selection_v1_device_manager *handle)
 {
-    return QWPrimarySelectionV1DeviceManagerPrivate::map.value(handle);
+    return static_cast<QWPrimarySelectionV1DeviceManager*>(QWPrimarySelectionV1DeviceManagerPrivate::map.value(handle));
 }
 
 QWPrimarySelectionV1DeviceManager *QWPrimarySelectionV1DeviceManager::from(wlr_primary_selection_v1_device_manager *handle)

--- a/src/types/qwprimaryselectionv1.h
+++ b/src/types/qwprimaryselectionv1.h
@@ -12,7 +12,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWPrimarySelectionV1DeviceManagerPrivate;
-class QW_EXPORT QWPrimarySelectionV1DeviceManager : public QObject, public QWObject
+class QW_EXPORT QWPrimarySelectionV1DeviceManager : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWPrimarySelectionV1DeviceManager)
@@ -24,9 +24,6 @@ public:
     static QWPrimarySelectionV1DeviceManager *get(wlr_primary_selection_v1_device_manager *handle);
     static QWPrimarySelectionV1DeviceManager *from(wlr_primary_selection_v1_device_manager *handle);
     static QWPrimarySelectionV1DeviceManager *create(QWDisplay *display);
-
-Q_SIGNALS:
-    void beforeDestroy(QWPrimarySelectionV1DeviceManager *self);
 
 private:
     QWPrimarySelectionV1DeviceManager(wlr_primary_selection_v1_device_manager *handle, bool isOwner);

--- a/src/types/qwrelativepointermanagerv1.cpp
+++ b/src/types/qwrelativepointermanagerv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwrelativepointerv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <qwseat.h>
@@ -15,55 +15,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWRelativeManagerV1Private : public QWObjectPrivate
+class QWRelativeManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWRelativeManagerV1Private(wlr_relative_pointer_manager_v1 *handle, bool isOwner, QWRelativeManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWRelativeManagerV1Private::on_destroy);
-    }
-    ~QWRelativeManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWRelativeManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWRelativeManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWRelativeManagerV1*> QWRelativeManagerV1Private::map;
-
-void QWRelativeManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWRelativeManagerV1Private::map;
 
 QWRelativeManagerV1::QWRelativeManagerV1(wlr_relative_pointer_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWRelativeManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWRelativeManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWRelativeManagerV1 *QWRelativeManagerV1::get(wlr_relative_pointer_manager_v1 *handle)
 {
-    return QWRelativeManagerV1Private::map.value(handle);
+    return static_cast<QWRelativeManagerV1*>(QWRelativeManagerV1Private::map.value(handle));
 }
 
 QWRelativeManagerV1 *QWRelativeManagerV1::from(wlr_relative_pointer_manager_v1 *handle)

--- a/src/types/qwrelativepointermanagerv1.cpp
+++ b/src/types/qwrelativepointermanagerv1.cpp
@@ -19,15 +19,13 @@ class QWRelativeManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWRelativeManagerV1Private(wlr_relative_pointer_manager_v1 *handle, bool isOwner, QWRelativeManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWRelativeManagerV1)
 };
-QHash<void*, QWWrapObject*> QWRelativeManagerV1Private::map;
 
 QWRelativeManagerV1::QWRelativeManagerV1(wlr_relative_pointer_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWRelativeManagerV1Private(handle, isOwner, this))

--- a/src/types/qwrelativepointerv1.cpp
+++ b/src/types/qwrelativepointerv1.cpp
@@ -16,15 +16,13 @@ class QWRelativeV1Private : public QWWrapObjectPrivate
 {
 public:
     QWRelativeV1Private(wlr_relative_pointer_v1 *handle, bool isOwner, QWRelativeV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWRelativeV1)
 };
-QHash<void*, QWWrapObject*> QWRelativeV1Private::map;
 
 QWRelativeV1::QWRelativeV1(wlr_relative_pointer_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWRelativeV1Private(handle, isOwner, this))

--- a/src/types/qwrelativepointerv1.h
+++ b/src/types/qwrelativepointerv1.h
@@ -12,7 +12,7 @@ struct wlr_relative_pointer_manager_v1;
 
 QW_BEGIN_NAMESPACE
 class QWRelativeV1Private;
-class QW_EXPORT QWRelativeV1 : public QObject, public QWObject
+class QW_EXPORT QWRelativeV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWRelativeV1)
@@ -25,9 +25,6 @@ public:
     static QWRelativeV1 *from(wlr_relative_pointer_v1 *handle);
     static QWRelativeV1 *fromResource(wl_resource *resource);
 
-Q_SIGNALS:
-    void beforeDestroy(QWRelativeV1 *self);
-
 private:
     QWRelativeV1(wlr_relative_pointer_v1 *handle, bool isOwner);
     ~QWRelativeV1() = default;
@@ -36,7 +33,7 @@ private:
 class QWSeat;
 class QWDisplay;
 class QWRelativeManagerV1Private;
-class QW_EXPORT QWRelativeManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWRelativeManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWRelativeManagerV1)
@@ -50,9 +47,6 @@ public:
     static QWRelativeManagerV1 *create(QWDisplay *display);
 
     void sendRelativeMotion(QWSeat *seat, uint64_t time_usec, const QPointF &pos, const QPointF & unaccelPos);
-
-Q_SIGNALS:
-    void beforeDestroy(QWRelativeManagerV1 *self);
 
 private:
     QWRelativeManagerV1(wlr_relative_pointer_manager_v1 *handle, bool isOwner);

--- a/src/types/qwscene.cpp
+++ b/src/types/qwscene.cpp
@@ -32,15 +32,13 @@ class QWSceneNodePrivate : public QWWrapObjectPrivate
 {
 public:
     QWSceneNodePrivate(wlr_scene_node *handle, bool isOwner, QWSceneNode *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_scene_node_destroy))
     {
 
     }
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSceneNode)
 };
-QHash<void*, QWWrapObject*> QWSceneNodePrivate::map;
 
 QWSceneNode::QWSceneNode(wlr_scene_node *handle, bool isOwner)
     : QWSceneNode(*new QWSceneNodePrivate(handle, isOwner, this))
@@ -411,15 +409,13 @@ class QWSceneOutputPrivate : public QWWrapObjectPrivate
 {
 public:
     QWSceneOutputPrivate(wlr_scene_output *handle, bool isOwner, QWSceneOutput *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_scene_output_destroy))
     {
 
     }
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSceneOutput)
 };
-QHash<void*, QWWrapObject*> QWSceneOutputPrivate::map;
 
 QWSceneOutput::QWSceneOutput(wlr_scene_output *handle, bool isOwner)
     : QWWrapObject(*new QWSceneOutputPrivate(handle, isOwner, this))

--- a/src/types/qwscene.h
+++ b/src/types/qwscene.h
@@ -42,7 +42,7 @@ QW_BEGIN_NAMESPACE
 class QWSurface;
 class QWXdgSurface;
 class QWSceneNodePrivate;
-class QW_EXPORT QWSceneNode : public QObject, public QWObject
+class QW_EXPORT QWSceneNode : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSceneNode)
@@ -66,9 +66,6 @@ public:
     bool coords(QPoint &pos) const;
     void forEachBuffer(wlr_scene_buffer_iterator_func_t iterator, void *userData) const;
     wlr_scene_node *at(const QPointF &lpos, QPointF *npos = nullptr) const;
-
-Q_SIGNALS:
-    void beforeDestroy(QWSceneNode *self);
 
 protected:
     QWSceneNode(QWSceneNodePrivate &dd, QObject *parent = nullptr);
@@ -177,7 +174,7 @@ private:
 
 class QWOutput;
 class QWSceneOutputPrivate;
-class QW_EXPORT QWSceneOutput : public QObject, public QWObject
+class QW_EXPORT QWSceneOutput : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSceneOutput)
@@ -197,9 +194,6 @@ public:
     void sendFrameDone(timespec *now);
 
     void forEachBuffer(wlr_scene_buffer_iterator_func_t iterator, void *user_data) const;
-
-Q_SIGNALS:
-    void beforeDestroy(QWSceneOutput *self);
 
 private:
     QWSceneOutput(wlr_scene_output *handle, bool isOwner);

--- a/src/types/qwscreencopyv1.cpp
+++ b/src/types/qwscreencopyv1.cpp
@@ -17,15 +17,13 @@ class QWScreenCopyManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWScreenCopyManagerV1Private(wlr_screencopy_manager_v1 *handle, bool isOwner, QWScreenCopyManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWScreenCopyManagerV1)
 };
-QHash<void*, QWWrapObject*> QWScreenCopyManagerV1Private::map;
 
 QWScreenCopyManagerV1::QWScreenCopyManagerV1(wlr_screencopy_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWScreenCopyManagerV1Private(handle, isOwner, this))

--- a/src/types/qwscreencopyv1.cpp
+++ b/src/types/qwscreencopyv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwscreencopyv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <QHash>
@@ -13,55 +13,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWScreenCopyManagerV1Private : public QWObjectPrivate
+class QWScreenCopyManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWScreenCopyManagerV1Private(wlr_screencopy_manager_v1 *handle, bool isOwner, QWScreenCopyManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWScreenCopyManagerV1Private::on_destroy);
-    }
-    ~QWScreenCopyManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWScreenCopyManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWScreenCopyManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWScreenCopyManagerV1*> QWScreenCopyManagerV1Private::map;
-
-void QWScreenCopyManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWScreenCopyManagerV1Private::map;
 
 QWScreenCopyManagerV1::QWScreenCopyManagerV1(wlr_screencopy_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWScreenCopyManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWScreenCopyManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWScreenCopyManagerV1 *QWScreenCopyManagerV1::get(wlr_screencopy_manager_v1 *handle)
 {
-    return QWScreenCopyManagerV1Private::map.value(handle);
+    return static_cast<QWScreenCopyManagerV1*>(QWScreenCopyManagerV1Private::map.value(handle));
 }
 
 QWScreenCopyManagerV1 *QWScreenCopyManagerV1::from(wlr_screencopy_manager_v1 *handle)

--- a/src/types/qwscreencopyv1.h
+++ b/src/types/qwscreencopyv1.h
@@ -12,7 +12,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWScreenCopyManagerV1Private;
-class QW_EXPORT QWScreenCopyManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWScreenCopyManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWScreenCopyManagerV1)
@@ -24,9 +24,6 @@ public:
     static QWScreenCopyManagerV1 *get(wlr_screencopy_manager_v1 *handle);
     static QWScreenCopyManagerV1 *from(wlr_screencopy_manager_v1 *handle);
     static QWScreenCopyManagerV1 *create(QWDisplay *display);
-
-Q_SIGNALS:
-    void beforeDestroy(QWScreenCopyManagerV1 *self);
 
 private:
     QWScreenCopyManagerV1(wlr_screencopy_manager_v1 *handle, bool isOwner);

--- a/src/types/qwseat.cpp
+++ b/src/types/qwseat.cpp
@@ -31,7 +31,7 @@ class QWSeatPrivate : public QWWrapObjectPrivate
 {
 public:
     QWSeatPrivate(wlr_seat *handle, bool isOwner, QWSeat *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_seat_destroy))
     {
         sc.connect(&handle->events.pointer_grab_begin, this, &QWSeatPrivate::on_pointer_grab_begin);
@@ -63,10 +63,8 @@ public:
     void on_request_start_drag(void *);
     void on_start_drag(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSeat)
 };
-QHash<void*, QWWrapObject*> QWSeatPrivate::map;
 
 void QWSeatPrivate::on_pointer_grab_begin(void *)
 {

--- a/src/types/qwseat.h
+++ b/src/types/qwseat.h
@@ -35,7 +35,7 @@ class QWSurface;
 class QWDisplay;
 class QWKeyboard;
 class QWSeatPrivate;
-class QW_EXPORT QWSeat : public QObject, public QWObject
+class QW_EXPORT QWSeat : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSeat)
@@ -126,7 +126,6 @@ public:
     bool surfaceAcceptsTouch(QWSurface *surface);
 
 Q_SIGNALS:
-    void beforeDestroy(QWSeat *self);
     void pointerGrabBegin();
     void pointerGrabEnd();
     void keyboardGrabBegin();

--- a/src/types/qwsecuritycontextmanagerv1.cpp
+++ b/src/types/qwsecuritycontextmanagerv1.cpp
@@ -3,7 +3,7 @@
 
 #include "qwsecuritycontextmanagerv1.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -13,55 +13,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWSecurityContextManagerV1Private : public QWObjectPrivate
+class QWSecurityContextManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWSecurityContextManagerV1Private(wlr_security_context_manager_v1 *handle, bool isOwner, QWSecurityContextManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWSecurityContextManagerV1Private::on_destroy);
-    }
-    ~QWSecurityContextManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWSecurityContextManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSecurityContextManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWSecurityContextManagerV1*> QWSecurityContextManagerV1Private::map;
-
-void QWSecurityContextManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWSecurityContextManagerV1Private::map;
 
 QWSecurityContextManagerV1::QWSecurityContextManagerV1(wlr_security_context_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWSecurityContextManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWSecurityContextManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWSecurityContextManagerV1 *QWSecurityContextManagerV1::get(wlr_security_context_manager_v1 *handle)
 {
-    return QWSecurityContextManagerV1Private::map.value(handle);
+    return static_cast<QWSecurityContextManagerV1*>(QWSecurityContextManagerV1Private::map.value(handle));
 }
 
 QWSecurityContextManagerV1 *QWSecurityContextManagerV1::from(wlr_security_context_manager_v1 *handle)

--- a/src/types/qwsecuritycontextmanagerv1.cpp
+++ b/src/types/qwsecuritycontextmanagerv1.cpp
@@ -17,15 +17,13 @@ class QWSecurityContextManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWSecurityContextManagerV1Private(wlr_security_context_manager_v1 *handle, bool isOwner, QWSecurityContextManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSecurityContextManagerV1)
 };
-QHash<void*, QWWrapObject*> QWSecurityContextManagerV1Private::map;
 
 QWSecurityContextManagerV1::QWSecurityContextManagerV1(wlr_security_context_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWSecurityContextManagerV1Private(handle, isOwner, this))

--- a/src/types/qwsecuritycontextmanagerv1.h
+++ b/src/types/qwsecuritycontextmanagerv1.h
@@ -15,7 +15,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWSecurityContextManagerV1Private;
-class QW_EXPORT QWSecurityContextManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWSecurityContextManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSecurityContextManagerV1)
@@ -29,9 +29,6 @@ public:
     static QWSecurityContextManagerV1 *create(QWDisplay *display);
 
     static const wlr_security_context_v1_state *lookupClient(QWSecurityContextManagerV1 *manager, wl_client *client);
-
-Q_SIGNALS:
-    void beforeDestroy(QWSecurityContextManagerV1 *self);
 
 private:
     QWSecurityContextManagerV1(wlr_security_context_manager_v1 *handle, bool isOwner);

--- a/src/types/qwsessionlockmanagerv1.cpp
+++ b/src/types/qwsessionlockmanagerv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwsessionlockv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <QHash>
@@ -13,46 +13,21 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWSessionLockManagerV1Private : public QWObjectPrivate
+class QWSessionLockManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWSessionLockManagerV1Private(wlr_session_lock_manager_v1 *handle, bool isOwner, QWSessionLockManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
         sc.connect(&handle->events.new_lock, this, &QWSessionLockManagerV1Private::on_new_lock);
-        sc.connect(&handle->events.destroy, this, &QWSessionLockManagerV1Private::on_destroy);
-    }
-    ~QWSessionLockManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_new_lock(wlr_session_lock_v1 *);
 
-    static QHash<void*, QWSessionLockManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSessionLockManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWSessionLockManagerV1*> QWSessionLockManagerV1Private::map;
-
-void QWSessionLockManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWSessionLockManagerV1Private::map;
 
 void QWSessionLockManagerV1Private::on_new_lock(wlr_session_lock_v1 *lock)
 {
@@ -60,15 +35,14 @@ void QWSessionLockManagerV1Private::on_new_lock(wlr_session_lock_v1 *lock)
 }
 
 QWSessionLockManagerV1::QWSessionLockManagerV1(wlr_session_lock_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWSessionLockManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWSessionLockManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWSessionLockManagerV1 *QWSessionLockManagerV1::get(wlr_session_lock_manager_v1 *handle)
 {
-    return QWSessionLockManagerV1Private::map.value(handle);
+    return static_cast<QWSessionLockManagerV1*>(QWSessionLockManagerV1Private::map.value(handle));
 }
 
 QWSessionLockManagerV1 *QWSessionLockManagerV1::from(wlr_session_lock_manager_v1 *handle)

--- a/src/types/qwsessionlockmanagerv1.cpp
+++ b/src/types/qwsessionlockmanagerv1.cpp
@@ -17,17 +17,15 @@ class QWSessionLockManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWSessionLockManagerV1Private(wlr_session_lock_manager_v1 *handle, bool isOwner, QWSessionLockManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_lock, this, &QWSessionLockManagerV1Private::on_new_lock);
     }
 
     void on_new_lock(wlr_session_lock_v1 *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSessionLockManagerV1)
 };
-QHash<void*, QWWrapObject*> QWSessionLockManagerV1Private::map;
 
 void QWSessionLockManagerV1Private::on_new_lock(wlr_session_lock_v1 *lock)
 {

--- a/src/types/qwsessionlocksurfacev1.cpp
+++ b/src/types/qwsessionlocksurfacev1.cpp
@@ -17,15 +17,13 @@ class QWSessionLockSurfaceV1Private : public QWWrapObjectPrivate
 {
 public:
     QWSessionLockSurfaceV1Private(wlr_session_lock_surface_v1 *handle, bool isOwner, QWSessionLockSurfaceV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSessionLockSurfaceV1)
 };
-QHash<void*, QWWrapObject*> QWSessionLockSurfaceV1Private::map;
 
 QWSessionLockSurfaceV1::QWSessionLockSurfaceV1(wlr_session_lock_surface_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWSessionLockSurfaceV1Private(handle, isOwner, this))

--- a/src/types/qwsessionlockv1.cpp
+++ b/src/types/qwsessionlockv1.cpp
@@ -17,7 +17,7 @@ class QWSessionLockV1Private : public QWWrapObjectPrivate
 {
 public:
     QWSessionLockV1Private(wlr_session_lock_v1 *handle, bool isOwner, QWSessionLockV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_session_lock_v1_destroy))
     {
         sc.connect(&handle->events.new_surface, this, &QWSessionLockV1Private::on_new_surface);
@@ -27,11 +27,9 @@ public:
     void on_new_surface(wlr_session_lock_surface_v1 *);
     void on_unlock();
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSessionLockV1)
 };
 
-QHash<void*, QWWrapObject*> QWSessionLockV1Private::map;
 
 void QWSessionLockV1Private::on_new_surface(wlr_session_lock_surface_v1 *surface)
 {

--- a/src/types/qwsessionlockv1.h
+++ b/src/types/qwsessionlockv1.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 
 class QWSurface;
 class QWSessionLockSurfaceV1Private;
-class QW_EXPORT QWSessionLockSurfaceV1 : public QObject, public QWObject
+class QW_EXPORT QWSessionLockSurfaceV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSessionLockSurfaceV1)
@@ -29,16 +29,13 @@ public:
 
     uint32_t configure(const QSize &size);
 
-Q_SIGNALS:
-    void beforeDestroy(QWSessionLockSurfaceV1 *self);
-
 private:
     QWSessionLockSurfaceV1(wlr_session_lock_surface_v1 *handle, bool isOwner);
     ~QWSessionLockSurfaceV1() = default;
 };
 
 class QWSessionLockV1Private;
-class QW_EXPORT QWSessionLockV1 : public QObject, public QWObject
+class QW_EXPORT QWSessionLockV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSessionLockV1)
@@ -55,7 +52,6 @@ public:
     void sendLocked();
 
 Q_SIGNALS:
-    void beforeDestroy(QWSessionLockV1 *self);
     void newSurface(QWSessionLockSurfaceV1 *);
     void unlock();
 
@@ -65,7 +61,7 @@ private:
 
 class QWDisplay;
 class QWSessionLockManagerV1Private;
-class QW_EXPORT QWSessionLockManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWSessionLockManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSessionLockManagerV1)
@@ -79,7 +75,6 @@ public:
     static QWSessionLockManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWSessionLockManagerV1 *self);
     void newLock(QWSessionLockV1 *);
 
 private:

--- a/src/types/qwsinglepixelbufferv1.cpp
+++ b/src/types/qwsinglepixelbufferv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwsinglepixelbufferv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <QHash>

--- a/src/types/qwsubcompositor.cpp
+++ b/src/types/qwsubcompositor.cpp
@@ -18,15 +18,13 @@ class QWSubcompositorPrivate : public QWWrapObjectPrivate
 {
 public:
     QWSubcompositorPrivate(wlr_subcompositor *handle, bool isOwner, QWSubcompositor *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSubcompositor)
 };
-QHash<void*, QWWrapObject*> QWSubcompositorPrivate::map;
 
 QWSubcompositor::QWSubcompositor(wlr_subcompositor *handle, bool isOwner)
     : QWWrapObject(*new QWSubcompositorPrivate(handle, isOwner, this))
@@ -58,15 +56,13 @@ class QWSubsurfacePrivate : public QWWrapObjectPrivate
 {
 public:
     QWSubsurfacePrivate(wlr_subsurface *handle, bool isOwner, QWSubsurface *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSubsurface)
 };
-QHash<void*, QWWrapObject*> QWSubsurfacePrivate::map;
 
 QWSubsurface::QWSubsurface(wlr_subsurface *handle, bool isOwner)
     : QWWrapObject(*new QWSubsurfacePrivate(handle, isOwner, this))

--- a/src/types/qwsubcompositor.cpp
+++ b/src/types/qwsubcompositor.cpp
@@ -4,7 +4,7 @@
 #include "qwsubcompositor.h"
 #include "qwcompositor.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -14,56 +14,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWSubcompositorPrivate : public QWObjectPrivate
+class QWSubcompositorPrivate : public QWWrapObjectPrivate
 {
 public:
     QWSubcompositorPrivate(wlr_subcompositor *handle, bool isOwner, QWSubcompositor *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWSubcompositorPrivate::on_destroy);
-    }
-    ~QWSubcompositorPrivate() {
-        if (!m_handle)
-            return;
-        destroy();
-        if (isHandleOwner)
-            qFatal("QWSubcompositor(%p) can't to destroy, its ownership is wl_display", q_func());
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWSubcompositor*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSubcompositor)
-    QWSignalConnector sc;
 };
-QHash<void*, QWSubcompositor*> QWSubcompositorPrivate::map;
-
-void QWSubcompositorPrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWSubcompositorPrivate::map;
 
 QWSubcompositor::QWSubcompositor(wlr_subcompositor *handle, bool isOwner)
-    : QWObject(*new QWSubcompositorPrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWSubcompositorPrivate(handle, isOwner, this))
 {
 
 }
 
 QWSubcompositor *QWSubcompositor::get(wlr_subcompositor *handle)
 {
-    return QWSubcompositorPrivate::map.value(handle);
+    return static_cast<QWSubcompositor*>(QWSubcompositorPrivate::map.value(handle));
 }
 
 QWSubcompositor *QWSubcompositor::from(wlr_subcompositor *handle)
@@ -81,56 +54,30 @@ QWSubcompositor *QWSubcompositor::create(QWDisplay *display)
     return new QWSubcompositor(subcompositor, true);
 }
 
-class QWSubsurfacePrivate : public QWObjectPrivate
+class QWSubsurfacePrivate : public QWWrapObjectPrivate
 {
 public:
     QWSubsurfacePrivate(wlr_subsurface *handle, bool isOwner, QWSubsurface *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWSubsurfacePrivate::on_destroy);
-    }
-    ~QWSubsurfacePrivate() {
-        if (!m_handle)
-            return;
-        destroy();
-        if (isHandleOwner)
-            qFatal("QWSubsurface(%p) can't to destroy, its ownership is wl_display", q_func());
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWSubsurface*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWSubsurface)
-    QWSignalConnector sc;
 };
-QHash<void*, QWSubsurface*> QWSubsurfacePrivate::map;
+QHash<void*, QWWrapObject*> QWSubsurfacePrivate::map;
 
 QWSubsurface::QWSubsurface(wlr_subsurface *handle, bool isOwner)
-    : QWObject(*new QWSubsurfacePrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWSubsurfacePrivate(handle, isOwner, this))
 {
 
 }
 
-void QWSubsurfacePrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
 
 QWSubsurface *QWSubsurface::get(wlr_subsurface *handle)
 {
-    return QWSubsurfacePrivate::map.value(handle);
+    return static_cast<QWSubsurface*>(QWSubsurfacePrivate::map.value(handle));
 }
 
 QWSubsurface *QWSubsurface::from(wlr_subsurface *handle)

--- a/src/types/qwsubcompositor.h
+++ b/src/types/qwsubcompositor.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 class QWSurface;
 class QWDisplay;
 class QWSubcompositorPrivate;
-class QW_EXPORT QWSubcompositor : public QObject, public QWObject
+class QW_EXPORT QWSubcompositor : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSubcompositor)
@@ -27,16 +27,13 @@ public:
     static QWSubcompositor *from(wlr_subcompositor *handle);
     static QWSubcompositor *create(QWDisplay *display);
 
-Q_SIGNALS:
-    void beforeDestroy(QWSubcompositor *self);
-
 private:
     QWSubcompositor(wlr_subcompositor *handle, bool isOwner);
     ~QWSubcompositor() = default;
 };
 
 class QWSubsurfacePrivate;
-class QW_EXPORT QWSubsurface : public QObject, public QWObject
+class QW_EXPORT QWSubsurface : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWSubsurface)
@@ -49,9 +46,6 @@ public:
     static QWSubsurface *get(wlr_subsurface *handle);
     static QWSubsurface *from(wlr_subsurface *handle);
     static QWSubsurface *tryFrom(QWSurface *surface);
-
-Q_SIGNALS:
-    void beforeDestroy(QWSubsurface *self);
 
 private:
     QWSubsurface(wlr_subsurface *handle, bool isOwner);

--- a/src/types/qwtablet.cpp
+++ b/src/types/qwtablet.cpp
@@ -3,7 +3,7 @@
 
 #include "qwtablet.h"
 #include "qwinputdevice_p.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 extern "C" {
 #include <wlr/types/wlr_tablet_tool.h>

--- a/src/types/qwtablet.h
+++ b/src/types/qwtablet.h
@@ -39,7 +39,7 @@ private:
 };
 
 class QWTabletToolPrivate;
-class QW_EXPORT QWTabletTool : public QObject, public QWObject
+class QW_EXPORT QWTabletTool : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTabletTool)
@@ -50,9 +50,6 @@ public:
 
     static QWTabletTool *get(wlr_tablet_tool *handle);
     static QWTabletTool *from(wlr_tablet_tool *handle);
-
-Q_SIGNALS:
-    void beforeDestroy(QWTabletTool *self);
 
 private:
     QWTabletTool(wlr_tablet_tool *handle, bool isOwner);

--- a/src/types/qwtabletmanagerv2.cpp
+++ b/src/types/qwtabletmanagerv2.cpp
@@ -20,15 +20,13 @@ class QWTabletManagerV2Private : public QWWrapObjectPrivate
 {
 public:
     QWTabletManagerV2Private(wlr_tablet_manager_v2 *handle, bool isOwner, QWTabletManagerV2 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTabletManagerV2)
 };
-QHash<void*, QWWrapObject*> QWTabletManagerV2Private::map;
 
 QWTabletManagerV2::QWTabletManagerV2(wlr_tablet_manager_v2 *handle, bool isOwner)
     : QWWrapObject(*new QWTabletManagerV2Private(handle, isOwner, this))

--- a/src/types/qwtabletpad.cpp
+++ b/src/types/qwtabletpad.cpp
@@ -3,7 +3,7 @@
 
 #include "qwtabletpad.h"
 #include "qwinputdevice_p.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 extern "C" {
 #include <wlr/types/wlr_tablet_pad.h>

--- a/src/types/qwtablettool.cpp
+++ b/src/types/qwtablettool.cpp
@@ -16,15 +16,13 @@ class QWTabletToolPrivate : public QWWrapObjectPrivate
 {
 public:
     QWTabletToolPrivate(wlr_tablet_tool *handle, bool isOwner, QWTabletTool *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTabletTool)
 };
-QHash<void*, QWWrapObject*> QWTabletToolPrivate::map;
 
 QWTabletTool::QWTabletTool(wlr_tablet_tool *handle, bool isOwner)
     : QWWrapObject(*new QWTabletToolPrivate(handle, isOwner, this))

--- a/src/types/qwtabletv2.h
+++ b/src/types/qwtabletv2.h
@@ -48,7 +48,7 @@ public:
 
 class QWSurface;
 class QWTabletV2TabletPrivate;
-class QW_EXPORT QWTabletV2Tablet : public QObject, public QWObject
+class QW_EXPORT QWTabletV2Tablet : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTabletV2Tablet)
@@ -64,9 +64,6 @@ public:
 
     bool canAcceptTablet(QWSurface *surface) const;
 
-Q_SIGNALS:
-    void beforeDestroy(QWTabletV2Tablet *self);
-
 private:
     explicit QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner, QWInputDevice *parent);
     ~QWTabletV2Tablet() = default;
@@ -74,7 +71,7 @@ private:
 
 class QWSurface;
 class QWTabletV2TabletToolPrivate;
-class QW_EXPORT QWTabletV2TabletTool : public QObject, public QWObject
+class QW_EXPORT QWTabletV2TabletTool : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTabletV2TabletTool)
@@ -118,7 +115,6 @@ public:
     bool hasImplicitGrab() const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWTabletV2TabletTool *self);
     void setCursor(wlr_tablet_v2_event_cursor *);
 
 private:
@@ -127,7 +123,7 @@ private:
 };
 
 class QWTabletV2TabletPadPrivate;
-class QW_EXPORT QWTabletV2TabletPad : public QObject, public QWObject
+class QW_EXPORT QWTabletV2TabletPad : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTabletV2TabletPad)
@@ -157,7 +153,6 @@ public:
     void startGrab(QWTabletPadV2Grab *grab);
 
 Q_SIGNALS:
-    void beforeDestroy(QWTabletV2TabletPad *self);
     void buttonFeedback(wlr_tablet_v2_event_feedback *);
     void ringFeedback(wlr_tablet_v2_event_feedback *);
     void stripFeedback(wlr_tablet_v2_event_feedback *);
@@ -171,7 +166,7 @@ class QWDisplay;
 class QWSeat;
 class QWInputDevice;
 class QWTabletManagerV2Private;
-class QW_EXPORT QWTabletManagerV2 : public QObject, public QWObject
+class QW_EXPORT QWTabletManagerV2 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTabletManagerV2)
@@ -187,9 +182,6 @@ public:
     QWTabletV2Tablet *createTablet(QWSeat *wlr_seat, QWInputDevice *wlr_device);
     QWTabletV2TabletPad *createPad(QWSeat *wlr_seat, QWInputDevice *wlr_device);
     QWTabletV2TabletTool *createTool(QWSeat *wlr_seat, wlr_tablet_tool *wlr_tool);
-
-Q_SIGNALS:
-    void beforeDestroy(QWTabletManagerV2 *self);
 
 private:
     QWTabletManagerV2(wlr_tablet_manager_v2 *handle, bool isOwner);

--- a/src/types/qwtabletv2tablepad.cpp
+++ b/src/types/qwtabletv2tablepad.cpp
@@ -18,7 +18,7 @@ class QWTabletV2TabletPadPrivate : public QWWrapObjectPrivate
 {
 public:
     QWTabletV2TabletPadPrivate(wlr_tablet_v2_tablet_pad *handle, bool isOwner, QWTabletV2TabletPad *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
+        : QWWrapObjectPrivate(handle, isOwner, qq)
     {
         sc.connect(&handle->events.button_feedback, this, &QWTabletV2TabletPadPrivate::on_button_feedback);
         sc.connect(&handle->events.ring_feedback, this, &QWTabletV2TabletPadPrivate::on_ring_feedback);
@@ -29,10 +29,8 @@ public:
     void on_ring_feedback(wlr_tablet_v2_event_feedback *);
     void on_strip_feedback(wlr_tablet_v2_event_feedback *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTabletV2TabletPad)
 };
-QHash<void*, QWWrapObject*> QWTabletV2TabletPadPrivate::map;
 
 void QWTabletV2TabletPadPrivate::on_button_feedback(wlr_tablet_v2_event_feedback *event)
 {

--- a/src/types/qwtabletv2tablet.cpp
+++ b/src/types/qwtabletv2tablet.cpp
@@ -3,7 +3,7 @@
 
 #include "qwtabletv2.h"
 #include "qwinputdevice.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwcompositor.h>
 #include <QHash>
@@ -14,53 +14,28 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWTabletV2TabletPrivate : public QWObjectPrivate
+class QWTabletV2TabletPrivate : public QWWrapObjectPrivate
 {
 public:
     QWTabletV2TabletPrivate(wlr_tablet_v2_tablet *handle, bool isOwner, QWTabletV2Tablet *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-    }
-    ~QWTabletV2TabletPrivate() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWTabletV2Tablet*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTabletV2Tablet)
-    QWSignalConnector sc;
 };
-QHash<void*, QWTabletV2Tablet*> QWTabletV2TabletPrivate::map;
-
-void QWTabletV2TabletPrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWTabletV2TabletPrivate::map;
 
 QWTabletV2Tablet::QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner, QWInputDevice *parent)
-    : QObject(parent)
-    , QWObject(*new QWTabletV2TabletPrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWTabletV2TabletPrivate(handle, isOwner, this), parent)
 {
 }
 
 QWTabletV2Tablet *QWTabletV2Tablet::get(wlr_tablet_v2_tablet *handle)
 {
-    return QWTabletV2TabletPrivate::map.value(handle);
+    return static_cast<QWTabletV2Tablet*>(QWTabletV2TabletPrivate::map.value(handle));
 }
 
 QWTabletV2Tablet *QWTabletV2Tablet::from(wlr_tablet_v2_tablet *handle)

--- a/src/types/qwtabletv2tablet.cpp
+++ b/src/types/qwtabletv2tablet.cpp
@@ -18,15 +18,13 @@ class QWTabletV2TabletPrivate : public QWWrapObjectPrivate
 {
 public:
     QWTabletV2TabletPrivate(wlr_tablet_v2_tablet *handle, bool isOwner, QWTabletV2Tablet *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
+        : QWWrapObjectPrivate(handle, isOwner, qq)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTabletV2Tablet)
 };
-QHash<void*, QWWrapObject*> QWTabletV2TabletPrivate::map;
 
 QWTabletV2Tablet::QWTabletV2Tablet(wlr_tablet_v2_tablet *handle, bool isOwner, QWInputDevice *parent)
     : QWWrapObject(*new QWTabletV2TabletPrivate(handle, isOwner, this), parent)

--- a/src/types/qwtabletv2tabletool.cpp
+++ b/src/types/qwtabletv2tabletool.cpp
@@ -19,7 +19,7 @@ class QWTabletV2TabletToolPrivate : public QWWrapObjectPrivate
 {
 public:
     QWTabletV2TabletToolPrivate(wlr_tablet_v2_tablet_tool *handle, bool isOwner, QWTabletV2TabletTool *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map)
+        : QWWrapObjectPrivate(handle, isOwner, qq)
     {
         sc.connect(&handle->events.set_cursor, this, &QWTabletV2TabletToolPrivate::on_set_cursor);
     }
@@ -28,10 +28,8 @@ public:
         Q_EMIT q_func()->setCursor(cursor);
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTabletV2TabletTool)
 };
-QHash<void*, QWWrapObject*> QWTabletV2TabletToolPrivate::map;
 
 QWTabletV2TabletTool::QWTabletV2TabletTool(wlr_tablet_v2_tablet_tool *handle, bool isOwner, QWTabletTool *parent)
     : QWWrapObject(*new QWTabletV2TabletToolPrivate(handle, isOwner, this), parent)

--- a/src/types/qwtextinputmanagerv3.cpp
+++ b/src/types/qwtextinputmanagerv3.cpp
@@ -17,17 +17,15 @@ class QWTextInputManagerV3Private : public QWWrapObjectPrivate
 {
 public:
     QWTextInputManagerV3Private(wlr_text_input_manager_v3 *handle, bool isOwner, QWTextInputManagerV3 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.text_input, this, &QWTextInputManagerV3Private::on_text_input);
     }
 
     void on_text_input(wlr_text_input_v3 *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTextInputManagerV3)
 };
-QHash<void*, QWWrapObject*> QWTextInputManagerV3Private::map;
 
 void QWTextInputManagerV3Private::on_text_input(wlr_text_input_v3 *input)
 {

--- a/src/types/qwtextinputv3.cpp
+++ b/src/types/qwtextinputv3.cpp
@@ -17,7 +17,7 @@ class QWTextInputV3Private : public QWWrapObjectPrivate
 {
 public:
     QWTextInputV3Private(wlr_text_input_v3 *handle, bool isOwner, QWTextInputV3 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.enable, this, &QWTextInputV3Private::on_enable);
         sc.connect(&handle->events.commit, this, &QWTextInputV3Private::on_commit);
@@ -28,10 +28,8 @@ public:
     void on_commit(wlr_text_input_v3 *);
     void on_disable(wlr_text_input_v3 *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWTextInputV3)
 };
-QHash<void*, QWWrapObject*> QWTextInputV3Private::map;
 
 void QWTextInputV3Private::on_enable(wlr_text_input_v3 *handle)
 {

--- a/src/types/qwtextinputv3.h
+++ b/src/types/qwtextinputv3.h
@@ -16,7 +16,7 @@ class QWSurface;
 class QWDisplay;
 class QWTextInputManagerV3;
 class QWTextInputV3Private;
-class QW_EXPORT QWTextInputV3 : public QObject, public QWObject
+class QW_EXPORT QWTextInputV3 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTextInputV3)
@@ -36,7 +36,6 @@ public:
     void sendDone();
 
 Q_SIGNALS:
-    void beforeDestroy(QWTextInputV3 *self);
     void enable(QWTextInputV3 *);
     void commit(QWTextInputV3 *);
     void disable(QWTextInputV3 *);
@@ -47,7 +46,7 @@ private:
 };
 
 class QWTextInputManagerV3Private;
-class QW_EXPORT QWTextInputManagerV3 : public QObject, public QWObject
+class QW_EXPORT QWTextInputManagerV3 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWTextInputManagerV3)
@@ -61,7 +60,6 @@ public:
     static QWTextInputManagerV3 *create(QWDisplay *wl_display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWTextInputManagerV3 *self);
     void textInput(QWTextInputV3 *);
 
 private:

--- a/src/types/qwtouch.cpp
+++ b/src/types/qwtouch.cpp
@@ -3,7 +3,7 @@
 
 #include "qwtouch.h"
 #include "qwinputdevice_p.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 extern "C" {
 #include <wlr/types/wlr_touch.h>

--- a/src/types/qwviewporter.cpp
+++ b/src/types/qwviewporter.cpp
@@ -17,15 +17,13 @@ class QWViewPorterPrivate : public QWWrapObjectPrivate
 {
 public:
     QWViewPorterPrivate(wlr_viewporter *handle, bool isOwner, QWViewPorter *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWViewPorter)
 };
-QHash<void*, QWWrapObject*> QWViewPorterPrivate::map;
 
 QWViewPorter::QWViewPorter(wlr_viewporter *handle, bool isOwner)
     : QWWrapObject(*new QWViewPorterPrivate(handle, isOwner, this))

--- a/src/types/qwviewporter.cpp
+++ b/src/types/qwviewporter.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwviewporter.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 #include "qwdisplay.h"
 
 #include <QHash>
@@ -13,55 +13,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWViewPorterPrivate : public QWObjectPrivate
+class QWViewPorterPrivate : public QWWrapObjectPrivate
 {
 public:
     QWViewPorterPrivate(wlr_viewporter *handle, bool isOwner, QWViewPorter *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWViewPorterPrivate::on_destroy);
-    }
-    ~QWViewPorterPrivate() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWViewPorter*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWViewPorter)
-    QWSignalConnector sc;
 };
-QHash<void*, QWViewPorter*> QWViewPorterPrivate::map;
-
-void QWViewPorterPrivate::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWViewPorterPrivate::map;
 
 QWViewPorter::QWViewPorter(wlr_viewporter *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWViewPorterPrivate(handle, isOwner, this))
+    : QWWrapObject(*new QWViewPorterPrivate(handle, isOwner, this))
 {
 
 }
 
 QWViewPorter *QWViewPorter::get(wlr_viewporter *handle)
 {
-    return QWViewPorterPrivate::map.value(handle);
+    return static_cast<QWViewPorter*>(QWViewPorterPrivate::map.value(handle));
 }
 
 QWViewPorter *QWViewPorter::from(wlr_viewporter *handle)

--- a/src/types/qwviewporter.h
+++ b/src/types/qwviewporter.h
@@ -12,7 +12,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWViewPorterPrivate;
-class QW_EXPORT QWViewPorter : public QObject, public QWObject
+class QW_EXPORT QWViewPorter : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWViewPorter)
@@ -24,9 +24,6 @@ public:
     static QWViewPorter *get(wlr_viewporter *handle);
     static QWViewPorter *from(wlr_viewporter *handle);
     static QWViewPorter *create(QWDisplay *display);
-
-Q_SIGNALS:
-    void beforeDestroy(QWViewPorter *self);
 
 private:
     QWViewPorter(wlr_viewporter *handle, bool isOwner);

--- a/src/types/qwvirtualkeyboardmanagerv1.cpp
+++ b/src/types/qwvirtualkeyboardmanagerv1.cpp
@@ -17,17 +17,15 @@ class QWVirtualKeyboardManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWVirtualKeyboardManagerV1Private(wlr_virtual_keyboard_manager_v1 *handle, bool isOwner, QWVirtualKeyboardManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_virtual_keyboard, this, &QWVirtualKeyboardManagerV1Private::on_new_virtual_keyboard);
     }
 
     void on_new_virtual_keyboard(wlr_virtual_keyboard_v1 *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWVirtualKeyboardManagerV1)
 };
-QHash<void*, QWWrapObject*> QWVirtualKeyboardManagerV1Private::map;
 
 void QWVirtualKeyboardManagerV1Private::on_new_virtual_keyboard(wlr_virtual_keyboard_v1 *handle)
 {

--- a/src/types/qwvirtualkeyboardmanagerv1.cpp
+++ b/src/types/qwvirtualkeyboardmanagerv1.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 
 #include "qwvirtualkeyboardv1.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <qwdisplay.h>
 #include <QHash>
@@ -13,46 +13,21 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWVirtualKeyboardManagerV1Private : public QWObjectPrivate
+class QWVirtualKeyboardManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWVirtualKeyboardManagerV1Private(wlr_virtual_keyboard_manager_v1 *handle, bool isOwner, QWVirtualKeyboardManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWVirtualKeyboardManagerV1Private::on_destroy);
         sc.connect(&handle->events.new_virtual_keyboard, this, &QWVirtualKeyboardManagerV1Private::on_new_virtual_keyboard);
     }
-    ~QWVirtualKeyboardManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_new_virtual_keyboard(wlr_virtual_keyboard_v1 *);
 
-    static QHash<void*, QWVirtualKeyboardManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWVirtualKeyboardManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWVirtualKeyboardManagerV1*> QWVirtualKeyboardManagerV1Private::map;
-
-void QWVirtualKeyboardManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWVirtualKeyboardManagerV1Private::map;
 
 void QWVirtualKeyboardManagerV1Private::on_new_virtual_keyboard(wlr_virtual_keyboard_v1 *handle)
 {
@@ -60,15 +35,14 @@ void QWVirtualKeyboardManagerV1Private::on_new_virtual_keyboard(wlr_virtual_keyb
 }
 
 QWVirtualKeyboardManagerV1::QWVirtualKeyboardManagerV1(wlr_virtual_keyboard_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWVirtualKeyboardManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWVirtualKeyboardManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWVirtualKeyboardManagerV1 *QWVirtualKeyboardManagerV1::get(wlr_virtual_keyboard_manager_v1 *handle)
 {
-    return QWVirtualKeyboardManagerV1Private::map.value(handle);
+    return static_cast<QWVirtualKeyboardManagerV1*>(QWVirtualKeyboardManagerV1Private::map.value(handle));
 }
 
 QWVirtualKeyboardManagerV1 *QWVirtualKeyboardManagerV1::from(wlr_virtual_keyboard_manager_v1 *handle)

--- a/src/types/qwvirtualkeyboardv1.cpp
+++ b/src/types/qwvirtualkeyboardv1.cpp
@@ -4,7 +4,7 @@
 #include "qwvirtualkeyboardv1.h"
 #include "qwkeyboard_p.h"
 #include "qwinputdevice.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 extern "C" {
 #include <wlr/types/wlr_virtual_keyboard_v1.h>

--- a/src/types/qwvirtualkeyboardv1.h
+++ b/src/types/qwvirtualkeyboardv1.h
@@ -33,7 +33,7 @@ private:
 
 class QWDisplay;
 class QWVirtualKeyboardManagerV1Private;
-class QW_EXPORT QWVirtualKeyboardManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWVirtualKeyboardManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWVirtualKeyboardManagerV1)
@@ -47,7 +47,6 @@ public:
     static QWVirtualKeyboardManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWVirtualKeyboardManagerV1 *self);
     void newVirtualKeyboard(QWVirtualKeyboardV1 *);
 
 private:

--- a/src/types/qwvirtualpointerv1.cpp
+++ b/src/types/qwvirtualpointerv1.cpp
@@ -20,17 +20,15 @@ class QWVirtualPointerManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWVirtualPointerManagerV1Private(wlr_virtual_pointer_manager_v1 *handle, bool isOwner, QWVirtualPointerManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_virtual_pointer, this, &QWVirtualPointerManagerV1Private::on_new_virtual_pointer);
     }
 
     void on_new_virtual_pointer(wlr_virtual_pointer_v1_new_pointer_event *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWVirtualPointerManagerV1)
 };
-QHash<void*, QWWrapObject*> QWVirtualPointerManagerV1Private::map;
 
 void QWVirtualPointerManagerV1Private::on_new_virtual_pointer(wlr_virtual_pointer_v1_new_pointer_event *event)
 {

--- a/src/types/qwvirtualpointerv1.h
+++ b/src/types/qwvirtualpointerv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWVirtualPointerManagerV1Private;
-class QW_EXPORT QWVirtualPointerManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWVirtualPointerManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWVirtualPointerManagerV1)
@@ -27,7 +27,6 @@ public:
     static QWVirtualPointerManagerV1 *create(QWDisplay *display);
 
 Q_SIGNALS:
-    void beforeDestroy(QWVirtualPointerManagerV1 *self);
     void newVirtualPointer(wlr_virtual_pointer_v1_new_pointer_event *);
 
 private:

--- a/src/types/qwxdgactivationtokenv1.cpp
+++ b/src/types/qwxdgactivationtokenv1.cpp
@@ -16,15 +16,13 @@ class QWXdgActivationTokenV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgActivationTokenV1Private(wlr_xdg_activation_token_v1 *handle, bool isOwner, QWXdgActivationTokenV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_xdg_activation_token_v1_destroy))
     {
 
     }
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgActivationTokenV1)
 };
-QHash<void*, QWWrapObject*> QWXdgActivationTokenV1Private::map;
 
 QWXdgActivationTokenV1::QWXdgActivationTokenV1(wlr_xdg_activation_token_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWXdgActivationTokenV1Private(handle, isOwner, this))

--- a/src/types/qwxdgactivationv1.cpp
+++ b/src/types/qwxdgactivationv1.cpp
@@ -17,7 +17,7 @@ class QWXdgActivationV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgActivationV1Private(wlr_xdg_activation_v1 *handle, bool isOwner, QWXdgActivationV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.request_activate, this, &QWXdgActivationV1Private::on_request_activate);
         sc.connect(&handle->events.new_token, this, &QWXdgActivationV1Private::on_new_token);
@@ -26,10 +26,8 @@ public:
     void on_request_activate(wlr_xdg_activation_v1_request_activate_event *);
     void on_new_token(wlr_xdg_activation_token_v1 *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgActivationV1)
 };
-QHash<void*, QWWrapObject*> QWXdgActivationV1Private::map;
 
 void QWXdgActivationV1Private::on_request_activate(wlr_xdg_activation_v1_request_activate_event *event)
 {

--- a/src/types/qwxdgactivationv1.h
+++ b/src/types/qwxdgactivationv1.h
@@ -12,7 +12,7 @@ struct wlr_xdg_activation_v1_request_activate_event;
 
 QW_BEGIN_NAMESPACE
 class QWXdgActivationTokenV1Private;
-class QW_EXPORT QWXdgActivationTokenV1 : public QObject, public QWObject
+class QW_EXPORT QWXdgActivationTokenV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgActivationTokenV1)
@@ -28,16 +28,13 @@ public:
 
     const char *getName() const;
 
-Q_SIGNALS:
-    void beforeDestroy(QWXdgActivationTokenV1 *self);
-
 private:
     QWXdgActivationTokenV1(wlr_xdg_activation_token_v1 *handle, bool isOwner);
 };
 
 class QWDisplay;
 class QWXdgActivationV1Private;
-class QW_EXPORT QWXdgActivationV1 : public QObject, public QWObject
+class QW_EXPORT QWXdgActivationV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgActivationV1)
@@ -55,7 +52,6 @@ public:
     QWXdgActivationTokenV1 *addToken(const char *token_str);
 
 Q_SIGNALS:
-    void beforeDestroy(QWXdgActivationV1 *self);
     void requestActivate(wlr_xdg_activation_v1_request_activate_event *);
     void newToken(QWXdgActivationTokenV1 *);
 

--- a/src/types/qwxdgdecorationmanagerv1.cpp
+++ b/src/types/qwxdgdecorationmanagerv1.cpp
@@ -24,17 +24,15 @@ class QWXdgDecorationManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgDecorationManagerV1Private(wlr_xdg_decoration_manager_v1 *handle, bool isOwner, QWXdgDecorationManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_toplevel_decoration, this, &QWXdgDecorationManagerV1Private::on_new_toplevel_decoration);
     }
 
     void on_new_toplevel_decoration(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgDecorationManagerV1)
 };
-QHash<void*, QWWrapObject*> QWXdgDecorationManagerV1Private::map;
 
 void QWXdgDecorationManagerV1Private::on_new_toplevel_decoration(void *data)
 {
@@ -74,17 +72,15 @@ class QWXdgToplevelDecorationV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgToplevelDecorationV1Private(wlr_xdg_toplevel_decoration_v1 *handle, bool isOwner, QWXdgToplevelDecorationV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.request_mode, this, &QWXdgToplevelDecorationV1Private::on_request_mode);
     }
 
     void on_request_mode(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgToplevelDecorationV1)
 };
-QHash<void*, QWWrapObject*> QWXdgToplevelDecorationV1Private::map;
 
 void QWXdgToplevelDecorationV1Private::on_request_mode(void *)
 {

--- a/src/types/qwxdgdecorationmanagerv1.cpp
+++ b/src/types/qwxdgdecorationmanagerv1.cpp
@@ -3,7 +3,7 @@
 
 #include "qwxdgdecorationmanagerv1.h"
 #include "qwdisplay.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -20,45 +20,21 @@ QW_BEGIN_NAMESPACE
 
 /// QWXdgDecorationManagerV1
 
-class QWXdgDecorationManagerV1Private : public QWObjectPrivate
+class QWXdgDecorationManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgDecorationManagerV1Private(wlr_xdg_decoration_manager_v1 *handle, bool isOwner, QWXdgDecorationManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWXdgDecorationManagerV1Private::on_destroy);
         sc.connect(&handle->events.new_toplevel_decoration, this, &QWXdgDecorationManagerV1Private::on_new_toplevel_decoration);
     }
-    ~QWXdgDecorationManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_new_toplevel_decoration(void *);
 
-    static QHash<void*, QWXdgDecorationManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgDecorationManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWXdgDecorationManagerV1*> QWXdgDecorationManagerV1Private::map;
-
-void QWXdgDecorationManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWXdgDecorationManagerV1Private::map;
 
 void QWXdgDecorationManagerV1Private::on_new_toplevel_decoration(void *data)
 {
@@ -67,15 +43,14 @@ void QWXdgDecorationManagerV1Private::on_new_toplevel_decoration(void *data)
 }
 
 QWXdgDecorationManagerV1::QWXdgDecorationManagerV1(wlr_xdg_decoration_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWXdgDecorationManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWXdgDecorationManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWXdgDecorationManagerV1 *QWXdgDecorationManagerV1::get(wlr_xdg_decoration_manager_v1 *handle)
 {
-    return QWXdgDecorationManagerV1Private::map.value(handle);
+    return static_cast<QWXdgDecorationManagerV1*>(QWXdgDecorationManagerV1Private::map.value(handle));
 }
 
 QWXdgDecorationManagerV1 *QWXdgDecorationManagerV1::from(wlr_xdg_decoration_manager_v1 *handle)
@@ -95,45 +70,21 @@ QWXdgDecorationManagerV1 *QWXdgDecorationManagerV1::create(QWDisplay *display)
 
 /// QWXdgToplevelDecorationV1
 
-class QWXdgToplevelDecorationV1Private : public QWObjectPrivate
+class QWXdgToplevelDecorationV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgToplevelDecorationV1Private(wlr_xdg_toplevel_decoration_v1 *handle, bool isOwner, QWXdgToplevelDecorationV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWXdgToplevelDecorationV1Private::on_destroy);
         sc.connect(&handle->events.request_mode, this, &QWXdgToplevelDecorationV1Private::on_request_mode);
     }
-    ~QWXdgToplevelDecorationV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
-    }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
     void on_request_mode(void *);
 
-    static QHash<void*, QWXdgToplevelDecorationV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgToplevelDecorationV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWXdgToplevelDecorationV1*> QWXdgToplevelDecorationV1Private::map;
-
-void QWXdgToplevelDecorationV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWXdgToplevelDecorationV1Private::map;
 
 void QWXdgToplevelDecorationV1Private::on_request_mode(void *)
 {
@@ -141,15 +92,14 @@ void QWXdgToplevelDecorationV1Private::on_request_mode(void *)
 }
 
 QWXdgToplevelDecorationV1::QWXdgToplevelDecorationV1(wlr_xdg_toplevel_decoration_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWXdgToplevelDecorationV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWXdgToplevelDecorationV1Private(handle, isOwner, this))
 {
 
 }
 
 QWXdgToplevelDecorationV1 *QWXdgToplevelDecorationV1::get(wlr_xdg_toplevel_decoration_v1 *handle)
 {
-    return QWXdgToplevelDecorationV1Private::map.value(handle);
+    return static_cast<QWXdgToplevelDecorationV1*>(QWXdgToplevelDecorationV1Private::map.value(handle));
 }
 
 QWXdgToplevelDecorationV1 *QWXdgToplevelDecorationV1::from(wlr_xdg_toplevel_decoration_v1 *handle)

--- a/src/types/qwxdgdecorationmanagerv1.h
+++ b/src/types/qwxdgdecorationmanagerv1.h
@@ -16,7 +16,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWXdgToplevelDecorationV1;
 class QWXdgDecorationManagerV1Private;
-class QW_EXPORT QWXdgDecorationManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWXdgDecorationManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgDecorationManagerV1)
@@ -38,7 +38,7 @@ private:
 };
 
 class QWXdgToplevelDecorationV1Private;
-class QW_EXPORT QWXdgToplevelDecorationV1 : public QObject, public QWObject
+class QW_EXPORT QWXdgToplevelDecorationV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgToplevelDecorationV1)

--- a/src/types/qwxdgforeignregistry.cpp
+++ b/src/types/qwxdgforeignregistry.cpp
@@ -18,23 +18,20 @@ class QWXdgForeignRegistryPrivate : public QWWrapObjectPrivate
 {
 public:
     QWXdgForeignRegistryPrivate(wlr_xdg_foreign_registry *handle, bool isOwner, QWXdgForeignRegistry *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignRegistry)
 };
-QHash<void*, QWWrapObject*> QWXdgForeignRegistryPrivate::map;
 
 QWXdgForeignExportedPrivate::QWXdgForeignExportedPrivate(wlr_xdg_foreign_exported *handle, bool isOwner, QWXdgForeignExported *qq)
-    : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+    : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
 {
 
 }
 
-QHash<void*, QWWrapObject*> QWXdgForeignExportedPrivate::map;
 
 QWXdgForeignRegistry *QWXdgForeignRegistry::create(QWDisplay *display)
 {

--- a/src/types/qwxdgforeignregistry.h
+++ b/src/types/qwxdgforeignregistry.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWXdgForeignExported;
 class QWXdgForeignRegistryPrivate;
-class QW_EXPORT QWXdgForeignRegistry : public QObject, public QWObject
+class QW_EXPORT QWXdgForeignRegistry : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgForeignRegistry)
@@ -28,16 +28,13 @@ public:
         return QWObject::handle<wlr_xdg_foreign_registry>();
     }
 
-Q_SIGNALS:
-    void beforeDestroy(QWXdgForeignRegistry *self);
-
 private:
     explicit QWXdgForeignRegistry(wlr_xdg_foreign_registry *handle, bool isOwner);
     ~QWXdgForeignRegistry() override = default;
 };
 
 class QWXdgForeignExportedPrivate;
-class QW_EXPORT QWXdgForeignExported : public QObject, public QWObject
+class QW_EXPORT QWXdgForeignExported : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgForeignExported)
@@ -52,11 +49,8 @@ public:
     bool init(QWXdgForeignRegistry *registry);
     void finish();
 
-Q_SIGNALS:
-    void beforeDestroy(QWXdgForeignExported *self);
-
 protected:
-    QWXdgForeignExported(QWObjectPrivate &dd);
+    QWXdgForeignExported(QWXdgForeignExportedPrivate &dd);
     virtual ~QWXdgForeignExported() override = default;
 
 private:

--- a/src/types/qwxdgforeignregistry_p.h
+++ b/src/types/qwxdgforeignregistry_p.h
@@ -5,23 +5,19 @@
 
 #include "qwsignalconnector.h"
 #include "qwxdgforeignregistry.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
 QW_BEGIN_NAMESPACE
 
-class QWXdgForeignExportedPrivate : public QWObjectPrivate
+class QWXdgForeignExportedPrivate : public QWWrapObjectPrivate
 {
 public:
     QWXdgForeignExportedPrivate(wlr_xdg_foreign_exported *handle, bool isOwner, QWXdgForeignExported *qq);
-    virtual ~QWXdgForeignExportedPrivate() override;
 
-    inline void destroy();
-    void on_destroy();
-
-    static QHash<void*, QWXdgForeignExported*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignExported)
-    QWSignalConnector sc;
 };
 
 QW_END_NAMESPACE

--- a/src/types/qwxdgforeignregistry_p.h
+++ b/src/types/qwxdgforeignregistry_p.h
@@ -16,7 +16,6 @@ class QWXdgForeignExportedPrivate : public QWWrapObjectPrivate
 public:
     QWXdgForeignExportedPrivate(wlr_xdg_foreign_exported *handle, bool isOwner, QWXdgForeignExported *qq);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignExported)
 };
 

--- a/src/types/qwxdgforeignv1.cpp
+++ b/src/types/qwxdgforeignv1.cpp
@@ -14,42 +14,19 @@ extern "C" {
 }
 
 QW_BEGIN_NAMESPACE
-class QWXdgForeignV1Private : public QWObjectPrivate
+class QWXdgForeignV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgForeignV1Private(wlr_xdg_foreign_v1 *handle, bool isOwner, QWXdgForeignV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWXdgForeignV1Private::on_destroy);
+
     }
 
-    ~QWXdgForeignV1Private() override {
-        if (!m_handle)
-            return;
-        destroy();
-    }
-
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    inline void on_destroy() {
-        destroy();
-        m_handle = nullptr;
-        delete q_func();
-    }
-
-    static QHash<void*, QWXdgForeignV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWXdgForeignV1*> QWXdgForeignV1Private::map;
+QHash<void*, QWWrapObject*> QWXdgForeignV1Private::map;
 
 class QWXdgExportedV1Private : public QWXdgForeignExportedPrivate
 {
@@ -78,12 +55,11 @@ QWXdgForeignV1* QWXdgForeignV1::from(wlr_xdg_foreign_v1 *handle)
 
 QWXdgForeignV1* QWXdgForeignV1::get(wlr_xdg_foreign_v1 *handle)
 {
-    return QWXdgForeignV1Private::map.value(handle);
+    return static_cast<QWXdgForeignV1*>(QWXdgForeignV1Private::map.value(handle));
 }
 
 QWXdgForeignV1::QWXdgForeignV1(wlr_xdg_foreign_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(* new QWXdgForeignV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWXdgForeignV1Private(handle, isOwner, this))
 {
 }
 

--- a/src/types/qwxdgforeignv1.cpp
+++ b/src/types/qwxdgforeignv1.cpp
@@ -18,15 +18,13 @@ class QWXdgForeignV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgForeignV1Private(wlr_xdg_foreign_v1 *handle, bool isOwner, QWXdgForeignV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignV1)
 };
-QHash<void*, QWWrapObject*> QWXdgForeignV1Private::map;
 
 class QWXdgExportedV1Private : public QWXdgForeignExportedPrivate
 {

--- a/src/types/qwxdgforeignv1.h
+++ b/src/types/qwxdgforeignv1.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWXdgForeignRegistry;
 class QWXdgForeignV1Private;
-class QW_EXPORT QWXdgForeignV1 : public QObject, public QWObject
+class QW_EXPORT QWXdgForeignV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgForeignV1)
@@ -25,9 +25,6 @@ public:
     inline wlr_xdg_foreign_v1 *handle() const {
         return QWObject::handle<wlr_xdg_foreign_v1>();
     }
-
-Q_SIGNALS:
-    void beforeDestroy(QWXdgForeignV1 *self);
 
 private:
     explicit QWXdgForeignV1(wlr_xdg_foreign_v1 *handle, bool isOwner);

--- a/src/types/qwxdgforeignv2.cpp
+++ b/src/types/qwxdgforeignv2.cpp
@@ -18,15 +18,13 @@ class QWXdgForeignv2Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgForeignv2Private(wlr_xdg_foreign_v2 *handle, bool isOwner, QWXdgForeignv2 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignv2)
 };
-QHash<void*, QWWrapObject*> QWXdgForeignv2Private::map;
 
 class QWXdgExportedv2Private : public QWXdgForeignExportedPrivate
 {

--- a/src/types/qwxdgforeignv2.cpp
+++ b/src/types/qwxdgforeignv2.cpp
@@ -14,42 +14,19 @@ extern "C" {
 }
 
 QW_BEGIN_NAMESPACE
-class QWXdgForeignv2Private : public QWObjectPrivate
+class QWXdgForeignv2Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgForeignv2Private(wlr_xdg_foreign_v2 *handle, bool isOwner, QWXdgForeignv2 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWXdgForeignv2Private::on_destroy);
+
     }
 
-    ~QWXdgForeignv2Private() override {
-        if (!m_handle)
-            return;
-        destroy();
-    }
-
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    inline void on_destroy() {
-        destroy();
-        m_handle = nullptr;
-        delete q_func();
-    }
-
-    static QHash<void*, QWXdgForeignv2*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgForeignv2)
-    QWSignalConnector sc;
 };
-QHash<void*, QWXdgForeignv2*> QWXdgForeignv2Private::map;
+QHash<void*, QWWrapObject*> QWXdgForeignv2Private::map;
 
 class QWXdgExportedv2Private : public QWXdgForeignExportedPrivate
 {
@@ -78,12 +55,11 @@ QWXdgForeignv2* QWXdgForeignv2::from(wlr_xdg_foreign_v2 *handle)
 
 QWXdgForeignv2* QWXdgForeignv2::get(wlr_xdg_foreign_v2 *handle)
 {
-    return QWXdgForeignv2Private::map.value(handle);
+    return static_cast<QWXdgForeignv2*>(QWXdgForeignv2Private::map.value(handle));
 }
 
 QWXdgForeignv2::QWXdgForeignv2(wlr_xdg_foreign_v2 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(* new QWXdgForeignv2Private(handle, isOwner, this))
+    : QWWrapObject(*new QWXdgForeignv2Private(handle, isOwner, this))
 {
 }
 

--- a/src/types/qwxdgforeignv2.h
+++ b/src/types/qwxdgforeignv2.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWXdgForeignRegistry;
 class QWXdgForeignv2Private;
-class QW_EXPORT QWXdgForeignv2 : public QObject, public QWObject
+class QW_EXPORT QWXdgForeignv2 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgForeignv2)
@@ -25,9 +25,6 @@ public:
     inline wlr_xdg_foreign_v2 *handle() const {
         return QWObject::handle<wlr_xdg_foreign_v2>();
     }
-
-Q_SIGNALS:
-    void beforeDestroy(QWXdgForeignv2 *self);
 
 private:
     explicit QWXdgForeignv2(wlr_xdg_foreign_v2 *handle, bool isOwner);

--- a/src/types/qwxdgoutputv1.cpp
+++ b/src/types/qwxdgoutputv1.cpp
@@ -4,7 +4,7 @@
 #include "qwxdgoutputv1.h"
 #include "qwdisplay.h"
 #include "qwoutputlayout.h"
-#include "util/qwsignalconnector.h"
+#include "private/qwglobal_p.h"
 
 #include <QHash>
 
@@ -17,55 +17,29 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-class QWXdgOutputManagerV1Private : public QWObjectPrivate
+class QWXdgOutputManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgOutputManagerV1Private(wlr_xdg_output_manager_v1 *handle, bool isOwner, QWXdgOutputManagerV1 *qq)
-        : QWObjectPrivate(handle, isOwner, qq)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
     {
-        Q_ASSERT(!map.contains(handle));
-        map.insert(handle, qq);
-        sc.connect(&handle->events.destroy, this, &QWXdgOutputManagerV1Private::on_destroy);
-    }
-    ~QWXdgOutputManagerV1Private() {
-        if (!m_handle)
-            return;
-        destroy();
+
     }
 
-    inline void destroy() {
-        Q_ASSERT(m_handle);
-        Q_ASSERT(map.contains(m_handle));
-        Q_EMIT q_func()->beforeDestroy(q_func());
-        map.remove(m_handle);
-        sc.invalidate();
-    }
-
-    void on_destroy(void *);
-
-    static QHash<void*, QWXdgOutputManagerV1*> map;
+    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgOutputManagerV1)
-    QWSignalConnector sc;
 };
-QHash<void*, QWXdgOutputManagerV1*> QWXdgOutputManagerV1Private::map;
-
-void QWXdgOutputManagerV1Private::on_destroy(void *)
-{
-    destroy();
-    m_handle = nullptr;
-    delete q_func();
-}
+QHash<void*, QWWrapObject*> QWXdgOutputManagerV1Private::map;
 
 QWXdgOutputManagerV1::QWXdgOutputManagerV1(wlr_xdg_output_manager_v1 *handle, bool isOwner)
-    : QObject(nullptr)
-    , QWObject(*new QWXdgOutputManagerV1Private(handle, isOwner, this))
+    : QWWrapObject(*new QWXdgOutputManagerV1Private(handle, isOwner, this))
 {
 
 }
 
 QWXdgOutputManagerV1 *QWXdgOutputManagerV1::get(wlr_xdg_output_manager_v1 *handle)
 {
-    return QWXdgOutputManagerV1Private::map.value(handle);
+    return static_cast<QWXdgOutputManagerV1*>(QWXdgOutputManagerV1Private::map.value(handle));
 }
 
 QWXdgOutputManagerV1 *QWXdgOutputManagerV1::from(wlr_xdg_output_manager_v1 *handle)

--- a/src/types/qwxdgoutputv1.cpp
+++ b/src/types/qwxdgoutputv1.cpp
@@ -21,15 +21,13 @@ class QWXdgOutputManagerV1Private : public QWWrapObjectPrivate
 {
 public:
     QWXdgOutputManagerV1Private(wlr_xdg_output_manager_v1 *handle, bool isOwner, QWXdgOutputManagerV1 *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
 
     }
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgOutputManagerV1)
 };
-QHash<void*, QWWrapObject*> QWXdgOutputManagerV1Private::map;
 
 QWXdgOutputManagerV1::QWXdgOutputManagerV1(wlr_xdg_output_manager_v1 *handle, bool isOwner)
     : QWWrapObject(*new QWXdgOutputManagerV1Private(handle, isOwner, this))

--- a/src/types/qwxdgoutputv1.h
+++ b/src/types/qwxdgoutputv1.h
@@ -14,7 +14,7 @@ QW_BEGIN_NAMESPACE
 class QWDisplay;
 class QWOutputLayout;
 class QWXdgOutputManagerV1Private;
-class QW_EXPORT QWXdgOutputManagerV1 : public QObject, public QWObject
+class QW_EXPORT QWXdgOutputManagerV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgOutputManagerV1)
@@ -26,9 +26,6 @@ public:
     static QWXdgOutputManagerV1 *get(wlr_xdg_output_manager_v1 *handle);
     static QWXdgOutputManagerV1 *from(wlr_xdg_output_manager_v1 *handle);
     static QWXdgOutputManagerV1 *create(QWDisplay *display, QWOutputLayout *layout);
-
-Q_SIGNALS:
-    void beforeDestroy(QWXdgOutputManagerV1 *self);
 
 private:
     QWXdgOutputManagerV1(wlr_xdg_output_manager_v1 *handle, bool isOwner);

--- a/src/types/qwxdgshell.cpp
+++ b/src/types/qwxdgshell.cpp
@@ -23,7 +23,7 @@ class QWXdgShellPrivate : public QWWrapObjectPrivate
 {
 public:
     QWXdgShellPrivate(wlr_xdg_shell *handle, bool isOwner, QWXdgShell *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.new_surface, this, &QWXdgShellPrivate::on_new_surface);
 #if WLR_VERSION_MINOR >= 18
@@ -38,10 +38,8 @@ public:
     void on_new_popup(void *data);
 #endif
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgShell)
 };
-QHash<void*, QWWrapObject*> QWXdgShellPrivate::map;
 
 void QWXdgShellPrivate::on_new_surface(void *data)
 {
@@ -92,7 +90,7 @@ public:
     // >0.18 role object's destory first then base's, connect to those to keep same behavior
     QWXdgSurfacePrivate(wlr_xdg_surface *handle, bool isOwner, QWXdgSurface *qq,
                         wl_signal *destroy_signal, std::function<void (void *)> destroy_function = nullptr)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, destroy_signal, destroy_function)
+        : QWWrapObjectPrivate(handle, isOwner, qq, destroy_signal, destroy_function)
     {
         sc.connect(&handle->events.ping_timeout, this, &QWXdgSurfacePrivate::on_ping_timeout);
         sc.connect(&handle->events.new_popup, this, &QWXdgSurfacePrivate::on_new_popup);
@@ -108,10 +106,8 @@ public:
     void on_configure(void *data);
     void on_ack_configure(void *data);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXdgSurface)
 };
-QHash<void*, QWWrapObject*> QWXdgSurfacePrivate::map;
 
 void QWXdgSurfacePrivate::on_ping_timeout(void *)
 {

--- a/src/types/qwxdgshell.h
+++ b/src/types/qwxdgshell.h
@@ -24,7 +24,7 @@ QW_BEGIN_NAMESPACE
 class QWSurface;
 class QWDisplay;
 class QWXdgShellPrivate;
-class QW_EXPORT QWXdgShell : public QObject, public QWObject
+class QW_EXPORT QWXdgShell : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgShell)
@@ -39,7 +39,6 @@ public:
     static QWXdgShell *from(wlr_xdg_shell *handle);
 
 Q_SIGNALS:
-    void beforeDestroy(QWXdgShell *self);
     void newSurface(wlr_xdg_surface *surface);
 #if WLR_VERSION_MINOR >= 18
     void newToplevel(wlr_xdg_toplevel *surface);
@@ -54,7 +53,7 @@ private:
 class QWXdgPopup;
 class QWXdgToplevel;
 class QWXdgSurfacePrivate;
-class QW_EXPORT QWXdgSurface : public QObject, public QWObject
+class QW_EXPORT QWXdgSurface : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXdgSurface)
@@ -82,7 +81,6 @@ public:
     void forEachPopupSurface(wlr_surface_iterator_func_t iterator, void *userData) const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWXdgSurface *self);
     void pingTimeout();
     void newPopup(QWXdgPopup *popup);
     void configure(wlr_xdg_surface_configure *conf);
@@ -91,7 +89,6 @@ Q_SIGNALS:
 
 protected:
     QWXdgSurface(QWXdgSurfacePrivate &dd);
-    QWXdgSurface(wlr_xdg_surface *handle, bool isOwner);
     ~QWXdgSurface() = default;
 };
 
@@ -117,7 +114,6 @@ public:
 Q_SIGNALS:
     void reposition();
 #if WLR_VERSION_MINOR >= 18
-    void beforeDestroy(QWXdgPopup *self);
 #endif
 
 private:
@@ -160,7 +156,6 @@ Q_SIGNALS:
     void titleChanged(char *newTitle);
     void appidChanged(char *newAppid);
 #if WLR_VERSION_MINOR >= 18
-    void beforeDestroy(QWXdgToplevel *self);
 #endif
 
 private:

--- a/src/types/qwxwayland.cpp
+++ b/src/types/qwxwayland.cpp
@@ -27,7 +27,7 @@ class QWXWaylandPrivate : public QWWrapObjectPrivate
 {
 public:
     QWXWaylandPrivate(wlr_xwayland *handle, QWXWayland *qq)
-        : QWWrapObjectPrivate(handle, false, qq, &map)
+        : QWWrapObjectPrivate(handle, false, qq)
     {
         sc.connect(&handle->events.ready, q_func(), &QWXWayland::ready);
         sc.connect(&handle->events.new_surface, this, &QWXWaylandPrivate::on_new_surface);
@@ -37,10 +37,8 @@ public:
     void on_new_surface(wlr_xwayland_surface *surface);
     void on_remove_startup_info(wlr_xwayland_remove_startup_info_event *event);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXWayland)
 };
-QHash<void*, QWWrapObject*> QWXWaylandPrivate::map;
 
 void QWXWaylandPrivate::on_new_surface(wlr_xwayland_surface *surface)
 {

--- a/src/types/qwxwayland.h
+++ b/src/types/qwxwayland.h
@@ -23,7 +23,7 @@ class QWSeat;
 class QWXWaylandServer;
 class QWXWaylandShellV1;
 class QWXWaylandPrivate;
-class QW_EXPORT QWXWayland : public QObject, public QWObject
+class QW_EXPORT QWXWayland : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXWayland)
@@ -36,7 +36,6 @@ public:
     void setSeat(QWSeat *seat);
 
 Q_SIGNALS:
-    void beforeDestroy(QWXWayland *self);
     void ready();
     void newSurface(wlr_xwayland_surface *surface);
     void removeStartupInfo(wlr_xwayland_remove_startup_info_event *event);

--- a/src/types/qwxwaylandserver.cpp
+++ b/src/types/qwxwaylandserver.cpp
@@ -16,7 +16,7 @@ class QWXWaylandServerPrivate : public QWWrapObjectPrivate
 {
 public:
     QWXWaylandServerPrivate(wlr_xwayland_server *handle, bool isOwner, QWXWaylandServer *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy,
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy,
                               toDestroyFunction(wlr_xwayland_server_destroy))
     {
         sc.connect(&handle->events.start, this, &QWXWaylandServerPrivate::on_start);
@@ -26,10 +26,8 @@ public:
     void on_start(void *);
     void on_ready(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXWaylandServer)
 };
-QHash<void*, QWWrapObject*> QWXWaylandServerPrivate::map;
 
 void QWXWaylandServerPrivate::on_start(void *)
 {

--- a/src/types/qwxwaylandserver.h
+++ b/src/types/qwxwaylandserver.h
@@ -13,7 +13,7 @@ QW_BEGIN_NAMESPACE
 
 class QWDisplay;
 class QWXWaylandServerPrivate;
-class QW_EXPORT QWXWaylandServer : public QObject, public QWObject
+class QW_EXPORT QWXWaylandServer : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXWaylandServer)
@@ -29,7 +29,6 @@ public:
     static QWXWaylandServer *create(QWDisplay *display, wlr_xwayland_server_options *options);
 
 Q_SIGNALS:
-    void beforeDestroy(QWXWaylandServer *self);
     void start();
     void ready();
 

--- a/src/types/qwxwaylandshellv1.cpp
+++ b/src/types/qwxwaylandshellv1.cpp
@@ -19,7 +19,7 @@ QW_BEGIN_NAMESPACE
 class QWXWaylandShellV1Private : public QWWrapObjectPrivate {
 public:
     QWXWaylandShellV1Private(wlr_xwayland_shell_v1* handle, QWXWaylandShellV1* qq)
-        : QWWrapObjectPrivate(handle, false, qq, &map)
+        : QWWrapObjectPrivate(handle, false, qq)
     {
         sc.connect(&handle->events.new_surface, this, &QWXWaylandShellV1Private::on_new_surface);
     }
@@ -33,10 +33,8 @@ public:
 
     void on_new_surface(wlr_xwayland_surface *surface);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXWaylandShellV1)
 };
-QHash<void*, QWWrapObject*> QWXWaylandShellV1Private::map;
 
 void QWXWaylandShellV1Private::on_new_surface(wlr_xwayland_surface *surface)
 {

--- a/src/types/qwxwaylandshellv1.h
+++ b/src/types/qwxwaylandshellv1.h
@@ -22,7 +22,7 @@ QW_BEGIN_NAMESPACE
 class QWSurface;
 class QWDisplay;
 class QWXWaylandShellV1Private;
-class QW_EXPORT QWXWaylandShellV1 : public QObject, public QWObject
+class QW_EXPORT QWXWaylandShellV1 : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXWaylandShellV1)
@@ -38,7 +38,6 @@ public:
     QWSurface *surfaceFromSerial(uint64_t serial) const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWXWaylandShellV1 *self);
     void newSurface(wlr_xwayland_surface *surface);
 
 private:

--- a/src/types/qwxwaylandsurface.cpp
+++ b/src/types/qwxwaylandsurface.cpp
@@ -25,7 +25,7 @@ class QWXWaylandSurfacePrivate : public QWWrapObjectPrivate
 {
 public:
     QWXWaylandSurfacePrivate(wlr_xwayland_surface *handle, bool isOwner, QWXWaylandSurface *qq)
-        : QWWrapObjectPrivate(handle, isOwner, qq, &map, &handle->events.destroy)
+        : QWWrapObjectPrivate(handle, isOwner, qq, &handle->events.destroy)
     {
         sc.connect(&handle->events.request_configure, this, &QWXWaylandSurfacePrivate::on_request_configure);
         sc.connect(&handle->events.request_move, this, &QWXWaylandSurfacePrivate::on_request_move);
@@ -77,10 +77,8 @@ public:
     void on_set_geometry(void *);
     void on_ping_timeout(void *);
 
-    static QHash<void*, QWWrapObject*> map;
     QW_DECLARE_PUBLIC(QWXWaylandSurface)
 };
-QHash<void*, QWWrapObject*> QWXWaylandSurfacePrivate::map;
 
 void QWXWaylandSurfacePrivate::on_request_configure(wlr_xwayland_surface_configure_event *event)
 {

--- a/src/types/qwxwaylandsurface.h
+++ b/src/types/qwxwaylandsurface.h
@@ -23,7 +23,7 @@ QW_BEGIN_NAMESPACE
 
 class QWSurface;
 class QWXWaylandSurfacePrivate;
-class QW_EXPORT QWXWaylandSurface : public QObject, public QWObject
+class QW_EXPORT QWXWaylandSurface : public QWWrapObject
 {
     Q_OBJECT
     QW_DECLARE_PRIVATE(QWXWaylandSurface)
@@ -46,7 +46,6 @@ public:
     wlr_xwayland_icccm_input_model_t icccmInputModel() const;
 
 Q_SIGNALS:
-    void beforeDestroy(QWXWaylandSurface *self);
     void requestConfigure(wlr_xwayland_surface_configure_event *event);
     void requestMove();
     void requestResize(wlr_xwayland_resize_event *event);


### PR DESCRIPTION
Refactor:

Using QWWrapObject for the class if it has wants inherit QWObject and QObject.

Remove beforeDestroy() signal from subclass of QWWrapObject, use QWWrapObject::beforeDestroy replace.

Move FooPrivate::destroy FooPrivate::on_destroy functions to WWrapObjectPrivate.