### PR TITLE
Hidden c/c++ symbol on default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,8 @@ set_target_properties(${TARGET}
         SOVERSION ${PROJECT_VERSION_MAJOR}
         PUBLIC_HEADER "${HEADERS}"
         EXPORT_NAME ${CMAKE_NAME}
+        CXX_VISIBILITY_PRESET hidden
+        C_VISIBILITY_PRESET hidden
 )
 
 target_link_libraries(${TARGET}


### PR DESCRIPTION
Fix build error when use qwlroots to a dynamic shared library:

relocation R_X86_64_PC32 against symbol `' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value.