### PR TITLE
Fix qw_interface

### DIFF
--- a/src/interfaces/qwbackendinterface.h
+++ b/src/interfaces/qwbackendinterface.h
@@ -22,15 +22,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(backend)
-{
-    QW_INTERFACE_INIT(backend)
-
-public:
-    QW_INTERFACE(start)
-    QW_INTERFACE(get_drm_fd)
-    QW_INTERFACE(get_buffer_caps)
-};
+QW_CLASS_INTERFACE(backend)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwbufferinterface.h
+++ b/src/interfaces/qwbufferinterface.h
@@ -12,16 +12,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(buffer)
-{
-    QW_INTERFACE_INIT(buffer)
-
-public:
-    QW_INTERFACE(get_dmabuf)
-    QW_INTERFACE(get_shm)
-    QW_INTERFACE(begin_data_ptr_access)
-    QW_INTERFACE(end_data_ptr_access)
-};
+QW_CLASS_INTERFACE(buffer)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwkeyboardinterface.h
+++ b/src/interfaces/qwkeyboardinterface.h
@@ -11,14 +11,6 @@ extern "C" {
 #include <wlr/interfaces/wlr_keyboard.h>
 }
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(keyboard)
-{
-    QW_INTERFACE_INIT(keyboard)
-
-public:
-    QW_INTERFACE(name)
-    QW_INTERFACE(led_update)
-};
+QW_CLASS_INTERFACE(keyboard)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwoutputinterface.h
+++ b/src/interfaces/qwoutputinterface.h
@@ -14,24 +14,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(output)
-{
-    QW_INTERFACE_INIT(output)
-
-public:
-    QW_INTERFACE(set_cursor)
-    QW_INTERFACE(move_cursor)
-    QW_INTERFACE(test)
-    QW_INTERFACE(commit)
-    QW_INTERFACE(get_gamma_size)
-    QW_INTERFACE(get_cursor_formats)
-#if WLR_VERSION_MINOR > 17
-    QW_INTERFACE(get_cursor_sizes)
-#else
-    QW_INTERFACE(get_cursor_size)
-#endif
-    QW_INTERFACE(get_primary_formats)
-};
+QW_CLASS_INTERFACE(output)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwpointerinterface.h
+++ b/src/interfaces/qwpointerinterface.h
@@ -12,13 +12,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(pointer)
-{
-    QW_INTERFACE_INIT(pointer)
-
-public:
-    QW_INTERFACE(name)
-};
+QW_CLASS_INTERFACE(pointer)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwrendererinterface.h
+++ b/src/interfaces/qwrendererinterface.h
@@ -17,38 +17,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(renderer)
-{
-    QW_INTERFACE_INIT(renderer)
-
-public:
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
-    QW_INTERFACE(bind_buffer)
-    QW_INTERFACE(begin)
-    QW_INTERFACE(end)
-    QW_INTERFACE(clear)
-    QW_INTERFACE(scissor)
-    QW_INTERFACE(render_subtexture_with_matrix)
-    QW_INTERFACE(render_quad_with_matrix)
-    QW_INTERFACE(get_shm_texture_formats)
-    QW_INTERFACE(get_dmabuf_texture_formats)
-#else // WLR_VERSION_MINOR >= 18
-    QW_INTERFACE(get_texture_formats)
-#endif
-    QW_INTERFACE(get_render_formats)
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
-    QW_INTERFACE(preferred_read_format)
-    QW_INTERFACE(read_pixels)
-#endif
-    QW_INTERFACE(destroy)
-    QW_INTERFACE(get_drm_fd)
-#if WLR_VERSION_MAJOR == 0 && WLR_VERSION_MINOR < 18
-    QW_INTERFACE(get_render_buffer_caps)
-#endif
-    QW_INTERFACE(texture_from_buffer)
-    QW_INTERFACE(begin_buffer_pass)
-    QW_INTERFACE(render_timer_create)
-};
+QW_CLASS_INTERFACE(renderer)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwswitchinterface.h
+++ b/src/interfaces/qwswitchinterface.h
@@ -12,13 +12,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(switch)
-{
-    QW_INTERFACE_INIT(switch)
-
-public:
-    QW_INTERFACE(name)
-};
+QW_CLASS_INTERFACE(switch)
 
 QW_END_NAMESPACE

--- a/src/interfaces/qwtabletpadinterface.h
+++ b/src/interfaces/qwtabletpadinterface.h
@@ -12,13 +12,6 @@ extern "C" {
 
 QW_BEGIN_NAMESPACE
 
-template<typename Derive>
-class QW_CLASS_INTERFACE(tablet_pad)
-{
-    QW_INTERFACE_INIT(tablet_pad)
-
-public:
-    QW_INTERFACE(name)
-};
+QW_CLASS_INTERFACE(tablet_pad)
 
 QW_END_NAMESPACE


### PR DESCRIPTION
Use QW_INTERFACE() macro to define interface implementation on the
    derive class, eg:
    
    class Foo : public qw_buffer_interface
    {
        QW_INTERFACE(end_data_ptr_access, void);
    };
