### PR TITLE
WIP

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,10 +200,10 @@ add_library(QWlroots::QWlroots ALIAS ${TARGET})
 set_target_properties(${TARGET}
     PROPERTIES
         VERSION ${CMAKE_PROJECT_VERSION}
-        SOVERSION ${PROJECT_VERSION_MAJOR}
         PUBLIC_HEADER "${HEADERS}"
         EXPORT_NAME ${CMAKE_NAME}
         POSITION_INDEPENDENT_CODE ON
+        INTERPROCEDURAL_OPTIMIZATION ON
 )
 
 target_link_libraries(${TARGET}


### PR DESCRIPTION
[   76s] qwlroots-static.aarch64: E: lto-no-text-in-archive (Badness: 10000) /usr/lib64/libqwlroots.a
[   76s] This archive does not contain a non-empty .text section.  The archive was not
[   76s] created with -ffat-lto-objects option.
[   76s] 