### PR TITLE
Allows to get qw_object's instances

### DIFF
--- a/src/qwobject.h
+++ b/src/qwobject.h
@@ -18,6 +18,18 @@ class QW_EXPORT qw_object_basic : public QObject {
 public:
     qw_object_basic (QObject *parent): QObject(parent) { }
 
+    template<typename T>
+    static inline QList<T*> get_objects() {
+        QList<T*> list;
+
+        for (const auto &i : std::as_const(map)) {
+            if (auto obj = qobject_cast<T*>(i))
+                list << obj;
+        }
+
+        return list;
+    }
+
 Q_SIGNALS:
     void before_destroy();
 
@@ -69,6 +81,10 @@ public:
                        static_cast<void*>(this));
             }
         }
+    }
+
+    static QW_ALWAYS_INLINE QList<Derive*> get_objects() {
+        return qw_object_basic::get_objects<Derive>();
     }
 
     static QW_ALWAYS_INLINE Derive *get(Handle *handle) {

--- a/tests/qwobject_test/test_qwobject.cpp
+++ b/tests/qwobject_test/test_qwobject.cpp
@@ -29,6 +29,9 @@ private:
 void testQWObject::initTestCase() {
     display = new qw_display();
     qabc = qw_abc::create(*display);
+    auto objects = qw_abc::get_objects();
+    QCOMPARE(objects.size(), 1);
+    QCOMPARE(objects.first(), qabc);
     connect(qabc, &qw_abc::notify_set_name, this, [this](const char *name){
         notified_name = name;
     });
@@ -55,6 +58,7 @@ void testQWObject::testsignal() {
 void testQWObject::cleanupTestCase() {
     delete display;
     QCOMPARE(qabc_destroyed, true);
+    QCOMPARE(qw_abc::get_objects().size(), 0);
 }
 
 QTEST_APPLESS_MAIN(testQWObject)


### PR DESCRIPTION
Compositor can check some qw_object class's instance if has memory leaks before application quit.