### PR TITLE
chore: forward log instead of wrap

### DIFF
--- a/src/util/qwlogging.h
+++ b/src/util/qwlogging.h
@@ -26,15 +26,15 @@ class qw_log
     {
         switch((int)verbosity) {
         case WLR_ERROR :
-            qCCritical(lcQWLog) << QString::vasprintf(fmt, args);
+            qCCritical(lcQWLog) << qPrintable(QString::vasprintf(fmt, args));
             break;
 
         case WLR_INFO :
-            qCInfo(lcQWLog) << QString::vasprintf(fmt, args);
+            qCInfo(lcQWLog) << qPrintable(QString::vasprintf(fmt, args));
             break;
 
         case WLR_DEBUG :
-            qCDebug(lcQWLog) << QString::vasprintf(fmt, args);
+            qCDebug(lcQWLog) << qPrintable(QString::vasprintf(fmt, args));
             break;
 
         default:


### PR DESCRIPTION
Wrapping log message from wlroots and printing it as a QString adds extra quotes to raw message. This might be confusing when log message itself contains double quotes. Just use qPrintable to forward log.