### PR TITLE
chore: update gitignore for IDE environments

### DIFF
--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,3 @@
+
+# Don't index SpecStory auto-save files, but allow explicit context inclusion via @ references
+.specstory/**

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ target_wrapper.*
 # QtCreator CMake
 CMakeLists.txt.user*
 
-# QtCreator 4.8< compilation database 
+# QtCreator 4.8< compilation database
 compile_commands.json
 
 # QtCreator local machine specific files for imported projects
@@ -62,3 +62,7 @@ result
 
 # vscode
 .vscode/
+qwlroots.code-workspace
+
+# cursor
+.specstory

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Copyright: None
 License: CC0-1.0
 
 # Project file
-Files: *.cmake *CMakeLists.txt *.pc.in *cmake.in .gitignore
+Files: *.cmake *CMakeLists.txt *.pc.in *cmake.in .gitignore .cursorindexingignore
 Copyright: None
 License: CC0-1.0
 


### PR DESCRIPTION
Update .gitignore to exclude files generated by Cursor and VSCode, preventing accidental commits of environment-specific and temporary files. This ensures a cleaner repository and avoids unnecessary bloat. Specifically, this adds .vscode/, qwlroots.code-workspace, .specstory and .cursorindexingignore to be ignored.

chore: 更新 .gitignore 以适配 IDE 环境

更新 .gitignore 文件，以排除由 Cursor 和 VSCode 生成的文件，防止意
外提交特定于环境的临时文件。这确保了更清晰的存储库，并避免了不必要的
膨胀。具体来说，添加了 .vscode/、qwlroots.code-workspace、.specstory 和 .cursorindexingignore 以被忽略。