### PR TITLE
fix: correct typo in build command description

### DIFF
--- a/.cursor/rules/public.mdc
+++ b/.cursor/rules/public.mdc
@@ -11,5 +11,5 @@ alwaysApply: true
 // Copyright (C) 2025 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
 6. 如果改动中有新增非代码类文件（如文档、图片），则要将这个新增文件的授权协议记录到 .reuse/dep5 中
-7. 在尝试编译时，如果已经存在 build 目录，则直接使用 cmake --build build 编译，无需使用 cmake -B buuild
+7. 在尝试编译时，如果已经存在 build 目录，则直接使用 cmake --build build 编译，无需使用 cmake -B build
 8. 新增的代码中的注释请使用英文


### PR DESCRIPTION
The typo "cmake -B buuild" was corrected to "cmake -B build" in the build command description within the public rules file. This ensures accurate instructions for users attempting to compile the project, preventing potential confusion.

fix: 修复构建命令描述中的拼写错误

在公共规则文件中，将构建命令描述中的拼写错误“cmake -B buuild”更正
为“cmake -B build”。此更改确保用户在尝试编译项目时获得准确的指示，避免可
能的混淆。